### PR TITLE
Initial implementation of AD integration role

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,77 +1,151 @@
-# Role Name
-![template](https://github.com/linux-system-roles/template/workflows/tox/badge.svg)
+# Direct AD Integration role
 
-A template for an ansible role which configures some GNU/Linux subsystem or
-service. A brief description of the role goes here.
+An ansible role which configures direct Active Directory integration.
+
+Supported Distributions
+-----------------------
+* RHEL7+, CentOS7+
+* Fedora
 
 ## Requirements
 
-Any pre-requisites that may not be covered by Ansible itself or the role should
-be mentioned here. For instance, if the role uses the EC2 module, it may be a
-good idea to mention in this section that the `boto` package is required.
+It is recommended to use the Administrator user to join with Active Directory. If the Administrator user cannot be used, the normal Active Directory user must have sufficient join permissions.
+
+Time must be in sync with Active Directory servers.  The ad_integration role will use the timesync system role for this if the user specifies `ad_integration_manage_timesync` to true and provides a value for `ad_integration_join_to_dc` to use as a timesource.
+
+RHEL8 (and newer) and Fedora no longer support RC4 encryption out of the box, it is recommended to enable AES in Active Directory, if not possible then the AD-SUPPORT crypto policy must be enabled.  The integration role will use the crypto_policies system role for this if the user sets the `ad_integration_manage_crypto_policies` and `ad_integration_allow_rc4_crypto` parameters to true.
+
+The Linux system must be able to resolve default AD DNS SRV records.
+
+Ports must be opened from Linux to AD:
+
+| Source Port | Destination | Protocol    | Service                                                   |
+|-------------|-------------|-------------|-----------------------------------------------------------|
+| 1024:65535  | 53          | TCP and UDP | DNS                                                       |
+| 1024:65535  | 389         | TCP and UDP | LDAP                                                      |
+| 1024:65535  | 636         | TCP         | LDAPS                                                     |
+| 1024:65535  | 88          | TCP and UDP | Kerberos                                                  |
+| 1024:65535  | 464         | TCP and UDP | Kerberos change/set password (kadmin)                     |
+| 1024:65535  | 3268        | TCP         | LDAP Global Catalog                                       |
+| 1024:65535  | 3269        | TCP         | LDAP Global Catalog SSL                                   |
+| 1024:65535  | 123         | UDP         | NTP/Chrony(Optional)                                      |
+| 1024:65535  | 323         | UDP         | NTP/Chrony (Optional)                                     |
+
 
 ## Role Variables
 
-A description of all input variables (i.e. variables that are defined in
-`defaults/main.yml`) for the role should go here as these form an API of the
-role.
+### Required variables
 
-Variables that are not intended as input, like variables defined in
-`vars/main.yml`, variables that are read from other roles and/or the global
-scope (ie. hostvars, group vars, etc.) can be also mentioned here but keep in
-mind that as these are probably not part of the role API they may change during
-the lifetime.
+#### ad_integration_realm
 
-Example of setting the variables:
+Active Directory realm, or domain name to join
 
-```yaml
-template_foo: "oof"
-template_bar: "baz"
-```
+#### ad_integration_password
 
-### Variables Exported by the Role
+The password of the user used to authenticate with when joining the machine to the realm.  Do not use cleartext - use Ansible Vault to encrypt the value.
 
-This section is optional.  Some roles may export variables for playbooks to
-use later.  These are analogous to "return values" in Ansible modules.  For
-example, if a role performs some action that will require a system reboot, but
-the user wants to defer the reboot, the role might set a variable like
-`template_reboot_needed: true` that the playbook can use to reboot at a more
-convenient time.
+### Optional variables
 
-Example:
+#### ad_integration_user
 
-`template_reboot_needed` - default `false` - if `true`, this means
-a reboot is needed to apply the changes made by the role
+The user name to be used to authenticate with when joining the machine to the realm.
+
+Default: Administrator
+
+#### ad_integration_join_to_dc
+
+an Active Directory domain controller's hostname (do not use IP address) may be specified to join via that domain controller directly.
+
+Default: Not set
+
+#### ad_integration_auto_id_mapping
+
+perform automatic UID/GID mapping for users and groups, set to `false` to rely on POSIX attributes already present in Active Directory.
+
+Default: true
+
+#### ad_integration_client_software
+
+Only join realms for which we can use the given client software. Possible values include sssd or winbind. Not all values are supported for all realms.
+
+Default: Automatic selection
+
+#### ad_integration_membership_software
+
+The software to use when joining to the realm. Possible values include samba or adcli. Not all values are supported for all realms.
+
+Default: Automatic selection
+
+#### ad_integration_computer_ou
+
+The distinguished name of an organizational unit to create the computer account. It can be relative to the Root DSE, or a complete LDAP DN.
+
+Default: Default AD computer container
+
+#### ad_integration_manage_timesync
+
+If true, the ad_integration role will use fedora.linux_system_roles.timesync. Requires providing a value for `ad_integration_timesync_source` to use as a time source.
+
+Default: false
+
+#### ad_integration_timesync_source
+
+Hostname or IP address of time source to synchronize the system clock with. Providing this variable automatically sets `ad_integration_manage_timesync` to true.
+
+#### ad_integration_manage_crypto_policies
+
+If true, the ad_integration role will use fedora.linux_system_roles.crypto_policies as needed
+
+Default: false
+
+#### ad_integration_allow_rc4_crypto
+
+If true, the ad_integration role will set the crypto policy allowing RC4 encryption. Providing this variable automatically sets ad_integration_manage_crypto_policies to true
+
+Default: false
+
+#### ad_integration_manage_dns
+
+If true, the ad_integration role will use fedora.linux_system_roles.network to add the provided dns server (see below) with manual DNS configuration to an existing connection. If true then the following variables are required:
+* `ad_integration_dns_server` - DNS server to add
+* `ad_integration_dns_connection_name` - Existing network connection name to configure
+* `ad_integration_dns_connection_type` - Existing network connection type to configure
+
+#### ad_integration_dns_server
+
+IP address of DNS server to add to existing networking configuration. Only applicable if `ad_integration_manage_dns` is true
+
+#### ad_integration_dns_connection_name
+
+The name option identifies the connection profile to be configured by the network role. It is not the name of the networking interface for which the profile applies. Only applicable if `ad_integration_manage_dns` is true
+
+#### ad_integration_dns_connection_type
+
+Network connection type such as ethernet, bridge, bond...etc, the network role contains a list of possible values. Only applicable if `ad_integration_manage_dns` is true
 
 ## Dependencies
 
-A list of other roles hosted on Galaxy should go here, plus any details in
-regards to parameters that may need to be set for other roles, or variables
-that are used from other roles.
+N/A
 
 ## Example Playbook
 
-Including an example of how to use your role (for instance, with variables
-passed in as parameters) is always nice for users too:
+The following is an example playbook to setup direct Active Directory integration with AD domain `domain.example.com`, the join will be performed with user Administrator using the vault stored password. Prior to the join, the crypto policy for AD SUPPORT with RC4 encryption allowed will be set.
 
 ```yaml
 - hosts: all
   vars:
-    template_foo: "foo foo!"
-    template_bar: "progress bar"
-
+    ad_integration_realm: "domain.example.com"
+    ad_integration_password: !vault | …vault encrypted password…
+    ad_integration_manage_crypto_policies: true
+    ad_integration_allow_rc4_crypto: true
   roles:
-    - linux-system-roles.template
+    - linux-system-roles.ad_integration
 ```
-
-More examples can be provided in the [`examples/`](examples) directory. These
-can be useful especially for documentation.
 
 ## License
 
-Whenever possible, please prefer MIT.
+MIT.
 
 ## Author Information
 
-An optional section for the role authors to include contact information, or a
-website (HTML is not allowed).
+Justin Stephenson (jstephen@redhat.com)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -39,3 +39,21 @@ ad_integration_manage_crypto_policies: false
 # If true, the ad_integration role will set the crypto policy allowing RC4 encryption.
 # Requires ad_integration_manage_crypto_policies to be set to true
 ad_integration_allow_rc4_crypto: false
+
+# If true, the ad_integration role will use fedora.linux_system_roles.network to configure an existing network connection DNS configuration (manual) to point to the provided AD DNS server.
+# If true then the following variables are required:
+# `ad_integration_dns_server`,              DNS Server to add to existing network connection
+# `ad_integration_dns_connection_name`,     Existing network connection name to configure
+# `ad_integration_dns_connection_type`      Existing Network connection type to configure
+ad_integration_manage_dns: false
+
+# IP address of DNS server to add to existing networking configuration
+ad_integration_dns_server: null
+
+# The name option identifies the connection profile to be configured by the network role. It is not the name of the networking interface for which the profile applies.
+# Only applicable if `ad_integration_manage_dns` is true
+ad_integration_dns_connection_name: null
+
+# Network connection type, the network role contains a list of possible values.
+# Only applicable if `ad_integration_manage_dns` is true
+ad_integration_dns_connection_type: null

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -32,3 +32,10 @@ ad_integration_manage_timesync: false
 
 # Hostname or IP address of time source to synchronize the system clock with. Only applicable if `ad_integration_manage_timesync` is true.
 ad_integration_timesync_source: null
+
+# If true, the ad_integration role will use fedora.linux_system_roles.crypto_policies as needed
+ad_integration_manage_crypto_policies: false
+
+# If true, the ad_integration role will set the crypto policy allowing RC4 encryption.
+# Requires ad_integration_manage_crypto_policies to be set to true
+ad_integration_allow_rc4_crypto: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,3 +26,9 @@ ad_integration_membership_software: "adcli"
 
 # The distinguished name of an organizational unit to create the computer account. It can be relative to the Root DSE, or a complete LDAP DN.
 ad_integration_computer_ou: null
+
+# If true, the ad_integration role will use fedora.linux_system_roles.timesync. `ad_integration_timesync_source` variable is required, time will then be synchronized with this server.
+ad_integration_manage_timesync: false
+
+# Hostname or IP address of time source to synchronize the system clock with. Only applicable if `ad_integration_manage_timesync` is true.
+ad_integration_timesync_source: null

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,9 +1,28 @@
-# SPDX-License-Identifier: MIT
 ---
 # Here is the right place to put the role's input variables.
 # This file also serves as a documentation for such a variables.
 
+## Required vars
 # Realm name to join
 ad_integration_realm: ""
 # Password of the user used to authenticate the join operation
 ad_integration_password: ""
+
+## Optional vars
+# Active Directory user used to join the domain
+ad_integration_user: "Administrator"
+
+# Active Directory domain controller's host name or IP address to join via that domain controller directly.
+ad_integration_join_to_dc: null
+
+# Turn it off to use UID and GID information stored in the directory (as-per RFC2307) rather than automatically generating UID and GID numbers
+ad_integration_auto_id_mapping: true
+
+# Control which client software is the preferred default for use with Active Directory. Possible values include sssd or winbind.
+ad_integration_client_software: "sssd"
+
+# The software to use when joining to the realm. Possible values include samba or adcli.
+ad_integration_membership_software: "adcli"
+
+# The distinguished name of an organizational unit to create the computer account. It can be relative to the Root DSE, or a complete LDAP DN.
+ad_integration_computer_ou: null

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -54,9 +54,9 @@ ad_integration_allow_rc4_crypto: false
 # to configure an existing network connection DNS configuration (manual)
 # to point to the provided AD DNS server.
 # If true then the following variables are required:
-# `ad_integration_dns_server`,              DNS Server to add to existing network connection
-# `ad_integration_dns_connection_name`,     Existing network connection name to configure
-# `ad_integration_dns_connection_type`      Existing Network connection type to configure
+# `ad_integration_dns_server`
+# `ad_integration_dns_connection_name`
+# `ad_integration_dns_connection_type`
 ad_integration_manage_dns: false
 
 # IP address of DNS server to add to existing networking configuration

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,20 +16,20 @@ ad_integration_user: "Administrator"
 # via that domain controller directly.
 ad_integration_join_to_dc: null
 
-# Turn it off to use UID and GID information stored in the directory (as-per RFC2307)
-# rather than automatically generating UID and GID numbers
+# Turn it off to use UID and GID information stored in the directory
+#  (as-per RFC2307) rather than automatically generating UID and GID numbers
 ad_integration_auto_id_mapping: true
 
-# Control which client software is the preferred default for use with Active Directory.
-# Possible values include sssd or winbind.
+# Control which client software is the preferred default for use with
+# Active Directory.  Possible values include sssd or winbind.
 ad_integration_client_software: "sssd"
 
 # The software to use when joining to the realm.
 # Possible values include samba or adcli.
 ad_integration_membership_software: "adcli"
 
-# The distinguished name of an organizational unit to create the computer account.
-# It can be relative to the Root DSE, or a complete LDAP DN.
+# The distinguished name of an organizational unit to create the computer
+# account.  It can be relative to the Root DSE, or a complete LDAP DN.
 ad_integration_computer_ou: null
 
 # If true, the ad_integration role will use fedora.linux_system_roles.timesync.
@@ -62,8 +62,9 @@ ad_integration_manage_dns: false
 # IP address of DNS server to add to existing networking configuration
 ad_integration_dns_server: null
 
-# The name option identifies the connection profile to be configured by the network role.
-# It is not the name of the networking interface for which the profile applies.
+# The name option identifies the connection profile to be configured by the
+# network role. It is not the name of the networking interface for which the
+# profile applies.
 # Only applicable if `ad_integration_manage_dns` is true
 ad_integration_dns_connection_name: null
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,35 +12,47 @@ ad_integration_password: ""
 # Active Directory user used to join the domain
 ad_integration_user: "Administrator"
 
-# Active Directory domain controller's host name or IP address to join via that domain controller directly.
+# Active Directory domain controller's host name or IP address to join
+# via that domain controller directly.
 ad_integration_join_to_dc: null
 
-# Turn it off to use UID and GID information stored in the directory (as-per RFC2307) rather than automatically generating UID and GID numbers
+# Turn it off to use UID and GID information stored in the directory (as-per RFC2307)
+# rather than automatically generating UID and GID numbers
 ad_integration_auto_id_mapping: true
 
-# Control which client software is the preferred default for use with Active Directory. Possible values include sssd or winbind.
+# Control which client software is the preferred default for use with Active Directory.
+# Possible values include sssd or winbind.
 ad_integration_client_software: "sssd"
 
-# The software to use when joining to the realm. Possible values include samba or adcli.
+# The software to use when joining to the realm.
+# Possible values include samba or adcli.
 ad_integration_membership_software: "adcli"
 
-# The distinguished name of an organizational unit to create the computer account. It can be relative to the Root DSE, or a complete LDAP DN.
+# The distinguished name of an organizational unit to create the computer account.
+# It can be relative to the Root DSE, or a complete LDAP DN.
 ad_integration_computer_ou: null
 
-# If true, the ad_integration role will use fedora.linux_system_roles.timesync. `ad_integration_timesync_source` variable is required, time will then be synchronized with this server.
+# If true, the ad_integration role will use fedora.linux_system_roles.timesync.
+# `ad_integration_timesync_source` variable is required,
+# time will then be synchronized with this server.
 ad_integration_manage_timesync: false
 
-# Hostname or IP address of time source to synchronize the system clock with. Only applicable if `ad_integration_manage_timesync` is true.
+# Hostname or IP address of time source to synchronize the system clock with.
+# Only applicable if `ad_integration_manage_timesync` is true.
 ad_integration_timesync_source: null
 
-# If true, the ad_integration role will use fedora.linux_system_roles.crypto_policies as needed
+# If true, the ad_integration role will use
+# fedora.linux_system_roles.crypto_policies as needed
 ad_integration_manage_crypto_policies: false
 
-# If true, the ad_integration role will set the crypto policy allowing RC4 encryption.
+# If true, the ad_integration role will set the crypto policy
+# allowing RC4 encryption.
 # Requires ad_integration_manage_crypto_policies to be set to true
 ad_integration_allow_rc4_crypto: false
 
-# If true, the ad_integration role will use fedora.linux_system_roles.network to configure an existing network connection DNS configuration (manual) to point to the provided AD DNS server.
+# If true, the ad_integration role will use fedora.linux_system_roles.network
+# to configure an existing network connection DNS configuration (manual)
+# to point to the provided AD DNS server.
 # If true then the following variables are required:
 # `ad_integration_dns_server`,              DNS Server to add to existing network connection
 # `ad_integration_dns_connection_name`,     Existing network connection name to configure
@@ -50,7 +62,8 @@ ad_integration_manage_dns: false
 # IP address of DNS server to add to existing networking configuration
 ad_integration_dns_server: null
 
-# The name option identifies the connection profile to be configured by the network role. It is not the name of the networking interface for which the profile applies.
+# The name option identifies the connection profile to be configured by the network role.
+# It is not the name of the networking interface for which the profile applies.
 # Only applicable if `ad_integration_manage_dns` is true
 ad_integration_dns_connection_name: null
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,51 +1,11 @@
 # SPDX-License-Identifier: MIT
 ---
 galaxy_info:
-  # Replace with role's author name:
-  author: John Doe <jdoe@corp.com>
-  # Replace with the real description of what is role's purpose:
-  description: Basic template for Linux system roles
-  # Replace with the company the role's author is member of:
-  company: John Doe, Inc.
-
-  # If the issue tracker for your role is not on github, uncomment the next
-  # line and provide a value
-  # issue_tracker_url: http://example.com/issue/tracker
-
-  # Some suggested licenses:
-  # - BSD (default)
-  # - MIT
-  # - GPLv2
-  # - GPLv3
-  # - Apache
-  # - CC-BY
+  author: Justin Stephenson <jstephen@redhat.com>
+  description: Direct AD Integration Role
+  company: Red Hat
   license: MIT
-
   min_ansible_version: "2.9"
-
-  # Optionally specify the branch Galaxy will use when accessing the GitHub
-  # repo for this role. During role install, if no tags are available, Galaxy
-  # will use this branch. During import Galaxy will access files on this
-  # branch. If Travis integration is configured, only notifications for this
-  # branch will be accepted. Otherwise, in all cases, the repo's default branch
-  # (usually master) will be used.
-  # github_branch:
-
-  #
-  # platforms is a list of platforms, and each platform has a name and a list
-  # of versions.
-  #
-  # platforms:
-  # - name: Fedora
-  #   versions:
-  #   - all
-  #   - 25
-  # - name: SomePlatform
-  #   versions:
-  #   - all
-  #   - 1.0
-  #   - 7
-  #   - 99.99
   platforms:
     # Replace the below with your platform list:
     - name: Fedora
@@ -53,16 +13,18 @@ galaxy_info:
         - all
     - name: EL
       versions:
-        - all
+        - 7
+        - 8
+        - 9
 
-  galaxy_tags: []
-  # List tags for your role here, one per line. A tag is a keyword that
-  # describes and categorizes the role. Users find roles by searching for tags.
-  # Be sure to remove the '[]' above, if you add tags to this list.
-  #
-  # NOTE: A tag is limited to a single word comprised of alphanumeric
-  #       characters. Maximum 20 tags per role.
+  galaxy_tags:
+    - ad
+    - activedirectory
+    - realmd
+    - sssd
+    - redhat
+    - fedora
+    - centos
+    - rhel
 
 dependencies: []
-# List your role dependencies here, one per line. Be sure to remove the '[]'
-# above, if you add dependencies to this list.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,6 +29,34 @@
 - name: Flush handlers
   meta: flush_handlers
 
-- name: Perform join operation
-  shell: echo {{ ad_integration_password }} | realm join {{ ad_integration_realm }}
-  when: not ansible_check_mode
+- name: Join to a specific Domain Controller
+  shell: |
+    set -euo pipefail
+    echo {{ ad_integration_password | quote }} | realm join -U \
+      {{ ad_integration_user | quote }} --membership-software \
+      {{ ad_integration_membership_software | quote }} \
+      {{ ad_integration_join_to_dc | quote }}
+  when:
+    - ad_integration_join_to_dc is not none
+    - not ansible_check_mode
+  register: __realm_join_output
+  failed_when:
+    - __realm_join_output is failed
+    - not __realm_join_output.stderr is search("Already joined to this domain")
+  changed_when: not __realm_join_output.stderr is search("Already joined to this domain")
+
+- name: Perform discovery-based realm join operation
+  shell: |
+    set -euo pipefail
+    echo {{ ad_integration_password | quote }} | realm join -U \
+      {{ ad_integration_user | quote }} --membership-software \
+      {{ ad_integration_membership_software | quote }} \
+      {{ ad_integration_realm | quote }}
+  when:
+    - ad_integration_join_to_dc is none
+    - not ansible_check_mode
+  register: __realm_join_output
+  failed_when:
+    - __realm_join_output is failed
+    - not __realm_join_output.stderr is search("Already joined to this domain")
+  changed_when: not __realm_join_output.stderr is search("Already joined to this domain")

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,11 +1,24 @@
 # SPDX-License-Identifier: MIT
 ---
-# Put the tasks for your role here.
+- name: Assume managing timesync if timesource is set
+  set_fact:
+    ad_integration_manage_timesync: true
+  when:
+    - ad_integration_timesync_source is not none
+    - ad_integration_timesync_source | length > 0
+
+- name: Ensure time source is provided if managing timesync
+  fail:
+    msg: >-
+      ad_integration_timesync_source must be provided if
+      manage timesync is true
+  when:
+    - ad_integration_manage_timesync | bool
+    - ad_integration_timesync_source is none
 
 - name: Set platform/version specific variables
   include_tasks: tasks/set_vars.yml
 
-# Examples of some tasks:
 - name: Ensure required packages are installed
   package:
     name: "{{ __ad_integration_packages }}"
@@ -28,6 +41,16 @@
 
 - name: Flush handlers
   meta: flush_handlers
+
+## Execute other roles if applicable
+- name: Manage timesync
+  include_role:
+   name: fedora.linux_system_roles.timesync
+  vars:
+    timesync_ntp_servers:
+      - hostname: "{{ ad_integration_timesync_source }}"
+        iburst: yes
+  when: ad_integration_manage_timesync | bool
 
 - name: Join to a specific Domain Controller
   shell: |

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,7 +16,7 @@
     - ad_integration_manage_timesync | bool
     - ad_integration_timesync_source is none
 
-  # Validate manage crypto variables
+# Validate manage crypto variables
 - name: Assume managing crypto policies if allow_rc4_crypto is set
   set_fact:
     ad_integration_manage_crypto_policies: true
@@ -32,7 +32,7 @@
     - ad_integration_allow_rc4_crypto | bool
     - not ad_integration_manage_crypto_policies
 
-  # Validate manage dns variables
+# Validate manage dns variables
 - name: Ensure all required dns variables are provided
   fail:
     msg: >-

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,6 +16,22 @@
     - ad_integration_manage_timesync | bool
     - ad_integration_timesync_source is none
 
+  # Validate manage crypto variables
+- name: Assume managing crypto policies if allow_rc4_crypto is set
+  set_fact:
+    ad_integration_manage_crypto_policies: true
+  when:
+    - ad_integration_allow_rc4_crypto | bool
+
+- name: Ensure manage_crypt_policies is set with crypto_allow_rc4
+  fail:
+    msg: >-
+      ad_integration_manage_crypto_policies must be true if
+      ad_integration_allow_rc4_crypto is true
+  when:
+    - ad_integration_allow_rc4_crypto | bool
+    - not ad_integration_manage_crypto_policies
+
 - name: Set platform/version specific variables
   include_tasks: tasks/set_vars.yml
 
@@ -51,6 +67,29 @@
       - hostname: "{{ ad_integration_timesync_source }}"
         iburst: yes
   when: ad_integration_manage_timesync | bool
+
+- name: Manage crypto policies
+  include_role:
+   name: fedora.linux_system_roles.crypto_policies
+  vars:
+    crypto_policies_policy: "DEFAULT:AD-SUPPORT"
+  when:
+    - ad_integration_manage_crypto_policies | bool
+    # Fedora and RHEL8+
+    - (ansible_distribution == "Fedora" or
+      (ansible_distribution in ['CentOS', 'RedHat'] and
+       ansible_distribution_version is version('8', '>=')))
+
+## RHEL9 uses the AD-SUPPORT-LEGACY policy for RC4, otherwise AD-SUPPORT allows it
+- name: Enable crypto policy allowing RC4 encryption
+  include_role:
+   name: fedora.linux_system_roles.crypto_policies
+  vars:
+    crypto_policies_policy: "DEFAULT:AD-SUPPORT-LEGACY"
+  when:
+    - ad_integration_allow_rc4_crypto | bool
+    - ansible_distribution in ['CentOS', 'RedHat']
+    - ansible_distribution_version is version('9', '>=')
 
 - name: Join to a specific Domain Controller
   shell: |

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -86,7 +86,7 @@
 
 - name: Manage timesync
   include_role:
-   name: fedora.linux_system_roles.timesync
+    name: fedora.linux_system_roles.timesync
   vars:
     timesync_ntp_servers:
       - hostname: "{{ ad_integration_timesync_source }}"
@@ -95,7 +95,7 @@
 
 - name: Manage crypto policies
   include_role:
-   name: fedora.linux_system_roles.crypto_policies
+    name: fedora.linux_system_roles.crypto_policies
   vars:
     crypto_policies_policy: "DEFAULT:AD-SUPPORT"
   when:
@@ -105,10 +105,11 @@
       (ansible_distribution in ['CentOS', 'RedHat'] and
        ansible_distribution_version is version('8', '>=')))
 
-## RHEL9 uses the AD-SUPPORT-LEGACY policy for RC4, otherwise AD-SUPPORT allows it
+## RHEL9 uses the AD-SUPPORT-LEGACY policy for RC4,
+## otherwise AD-SUPPORT allows it
 - name: Enable crypto policy allowing RC4 encryption
   include_role:
-   name: fedora.linux_system_roles.crypto_policies
+    name: fedora.linux_system_roles.crypto_policies
   vars:
     crypto_policies_policy: "DEFAULT:AD-SUPPORT-LEGACY"
   when:
@@ -130,7 +131,8 @@
   failed_when:
     - __realm_join_output is failed
     - not __realm_join_output.stderr is search("Already joined to this domain")
-  changed_when: not __realm_join_output.stderr is search("Already joined to this domain")
+  changed_when: not __realm_join_output.stderr is
+    search("Already joined to this domain")
 
 - name: Perform discovery-based realm join operation
   shell: |
@@ -146,4 +148,5 @@
   failed_when:
     - __realm_join_output is failed
     - not __realm_join_output.stderr is search("Already joined to this domain")
-  changed_when: not __realm_join_output.stderr is search("Already joined to this domain")
+  changed_when: not __realm_join_output.stderr is
+    search("Already joined to this domain")

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,6 +32,18 @@
     - ad_integration_allow_rc4_crypto | bool
     - not ad_integration_manage_crypto_policies
 
+  # Validate manage dns variables
+- name: Ensure all required dns variables are provided
+  fail:
+    msg: >-
+      ad_integration_dns_server, ad_integration_dns_connection_name, and
+      ad_integration_dns_connection_type must be provided if manage dns is true
+  when:
+    - ad_integration_manage_dns | bool
+    - (ad_integration_dns_server is none or
+       ad_integration_dns_connection_name is none or
+       ad_integration_dns_connection_type is none)
+
 - name: Set platform/version specific variables
   include_tasks: tasks/set_vars.yml
 
@@ -59,6 +71,19 @@
   meta: flush_handlers
 
 ## Execute other roles if applicable
+- name: Add AD server to existing network connection for DNS
+  include_role:
+    name: fedora.linux_system_roles.network
+  vars:
+    network_connections:
+      - name: "{{ ad_integration_dns_connection_name }}"
+        interface_name: ""
+        type: "{{ ad_integration_dns_connection_type }}"
+        ip:
+          dns: "{{ ad_integration_dns_server }}"
+    network_allow_restart: yes
+  when: ad_integration_manage_dns | bool
+
 - name: Manage timesync
   include_role:
    name: fedora.linux_system_roles.timesync

--- a/tasks/set_vars.yml
+++ b/tasks/set_vars.yml
@@ -3,7 +3,8 @@
   setup:
     gather_subset: min
   when: not ansible_facts.keys() | list |
-    intersect(__ad_integration_required_facts) == __ad_integration_required_facts
+    intersect(__ad_integration_required_facts) ==
+    __ad_integration_required_facts
 
 - name: Set platform/version specific variables
   include_vars: "{{ __vars_file }}"

--- a/templates/realmd.conf.j2
+++ b/templates/realmd.conf.j2
@@ -1,4 +1,11 @@
 # SPDX-License-Identifier: MIT
 #
 {{ ansible_managed | comment }}
+[active-directory]
+default-client = {{ ad_integration_client_software }}
+
 [{{ ad_integration_realm }}]
+automatic-id-mapping = {{ ad_integration_auto_id_mapping }}
+{% if ad_integration_computer_ou %}
+computer-ou = {{ ad_integration_computer_ou }}
+{% endif %}


### PR DESCRIPTION
Direct AD integration role, tested with RHEL7, RHEL8, RHEL9 against all supported Windows Server AD versions.

I'm undecided if the commit [Support including the Network role](https://github.com/linux-system-roles/ad_integration/commit/6fccb4dd2e85a00d51e2a8a7dc824af7b5234eff) is needed. It helps me in my simplified testing with this role, but I don't know if it will be worthwhile for real customer use cases. I included it for now but I am fine to drop it.