### PR TITLE
python version depends on platform; upgrade checkout, setup-python; support py311 [citest skip]

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -4,24 +4,37 @@ on:  # yamllint disable-line rule:truthy
   - pull_request
   - push
 env:
-  TOX_LSR: "git+https://github.com/linux-system-roles/tox-lsr@main"
+  TOX_LSR: "git+https://github.com/linux-system-roles/tox-lsr@2.13.0"
+  LSR_ANSIBLE_TEST_DOCKER: "true"
   LSR_ANSIBLES: 'ansible==2.9.*'
   LSR_MSCENARIOS: default
   # LSR_EXTRA_PACKAGES: libdbus-1-dev
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   python:
-    runs-on: ubuntu-latest
     strategy:
       matrix:
-        pyver: ['2.7', '3.6', '3.8', '3.9', '3.10']
+        pyver_os:
+          - ver: '2.7'
+            os: ubuntu-20.04
+          - ver: '3.6'
+            os: ubuntu-20.04
+          - ver: '3.8'
+            os: ubuntu-latest
+          - ver: '3.9'
+            os: ubuntu-latest
+          - ver: '3.10'
+            os: ubuntu-latest
+          - ver: '3.11'
+            os: ubuntu-latest
+    runs-on: ${{ matrix.pyver_os.os }}
     steps:
       - name: checkout PR
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.pyver }}
+          python-version: ${{ matrix.pyver_os.ver }}
       - name: Install platform dependencies, python, tox, tox-lsr
         run: |
           set -euxo pipefail
@@ -33,13 +46,14 @@ jobs:
       - name: Run tox tests
         run: |
           set -euxo pipefail
-          toxpyver=$(echo "${{ matrix.pyver }}" | tr -d .)
+          toxpyver=$(echo "${{ matrix.pyver_os.ver }}" | tr -d .)
           toxenvs="py${toxpyver}"
           case "$toxpyver" in
           27) toxenvs="${toxenvs},coveralls,flake8,pylint" ;;
           36) toxenvs="${toxenvs},coveralls,black,yamllint,shellcheck" ;;
           38) toxenvs="${toxenvs},coveralls,ansible-lint,ansible-plugin-scan,collection,ansible-test" ;;
           39) toxenvs="${toxenvs},coveralls,ansible-managed-var-comment" ;;
-          310) toxenvs="${toxenvs},coveralls,custom" ;;
+          310) toxenvs="${toxenvs},coveralls,check-meta-versions" ;;
+          311) toxenvs="${toxenvs},coveralls" ;;
           esac
           TOXENV="$toxenvs" lsr_ci_runtox


### PR DESCRIPTION
The python version used now requires a corresponding os version e.g. python 2.7 and
python 3.6 are no longer supported on ubuntu-latest - must use 20.04.  Update
the python matrix to include the os to use as well.

Use checkout@v3 and setup-python@v4

python 3.11 stable is now supported by setup-python

Add `push` action for status reporting on role main page if missing

Use `docker` for ansible-test if not already doing that

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
