### PR TITLE
Add `state: up` for the network role to activate the connection

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -87,6 +87,7 @@
         type: "{{ ad_integration_dns_connection_type }}"
         ip:
           dns: "{{ ad_integration_dns_server }}"
+        state: up
     network_allow_restart: true
   when: ad_integration_manage_dns | bool
 


### PR DESCRIPTION
I have been testing ad_integration and found out that it requires to set state: up for the network role's network_connections.
Without `state: up`, the not existing connection is created but is not activated on the node, so the previously active connection that doesn't have the required DNS record in `/etc/resolv.conf` is being active
And if updating the connection that is being active, the configuration is not applied without `state: up`, so the required DNS record is not appearing in `/etc/resolv.conf`.
