### PR TITLE
Fingerprint RHEL System Role managed config files

### DIFF
--- a/templates/realmd.conf.j2
+++ b/templates/realmd.conf.j2
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MIT
 #
 {{ ansible_managed | comment }}
+{{ "system_role:ad_integration" | comment(prefix="", postfix="") }}
 [active-directory]
 default-client = {{ ad_integration_client_software }}
 


### PR DESCRIPTION
Add role name to the generated config files.
```
# system_role:ad_integration
```
Note: This information is provided to help customers identify that it was generated by System Roles. It may also be used for future analysis.