### PR TITLE
refactor: improve support for ostree systems

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -21,7 +21,6 @@ exclude_paths:
   - .markdownlint.yaml
   - examples/roles/
 mock_modules:
-  - ansible.utils.update_fact
   - win_domain_group
   - win_domain_user
   - community.general.ini_file

--- a/meta/collection-requirements.yml
+++ b/meta/collection-requirements.yml
@@ -1,5 +1,4 @@
 ---
 collections:
   - name: ansible.posix
-  - name: ansible.utils
   - name: community.general

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -55,6 +55,8 @@
   package:
     name: "{{ __ad_integration_packages }}"
     state: present
+    use: "{{ (__ad_integration_is_ostree | d(false)) |
+      ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
 
 - name: Ensure required services are enabled and started
   service:

--- a/tasks/set_vars.yml
+++ b/tasks/set_vars.yml
@@ -5,23 +5,17 @@
   when: __ad_integration_required_facts |
     difference(ansible_facts.keys() | list) | length > 0
 
-- name: Ensure correct package manager for ostree systems
-  vars:
-    ostree_pkg_mgr: ansible.posix.rhel_rpm_ostree
-    ostree_booted_file: /run/ostree-booted
-  when: ansible_facts.pkg_mgr | d("") != ostree_pkg_mgr
+- name: Determine if system is ostree and set flag
+  when: not __ad_integration_is_ostree is defined
   block:
     - name: Check if system is ostree
       stat:
-        path: "{{ ostree_booted_file }}"
+        path: /run/ostree-booted
       register: __ostree_booted_stat
 
-    - name: Set package manager to use for ostree
-      ansible.utils.update_fact:
-        updates:
-          - path: ansible_facts.pkg_mgr
-            value: "{{ ostree_pkg_mgr }}"
-      when: __ostree_booted_stat.stat.exists
+    - name: Set flag to indicate system is ostree
+      set_fact:
+        __ad_integration_is_ostree: "{{ __ostree_booted_stat.stat.exists }}"
 
 - name: Set platform/version specific variables
   include_vars: "{{ __vars_file }}"


### PR DESCRIPTION
The dependency on `ansible.utils.update_fact` is causing issue with
some users who now must install that collection in order to run
the role, even if they do not care about ostree.

The fix is to stop trying to set `ansible_facts.pkg_mgr`, and instead
force the use of the ostree package manager with the `package:` module
`use:` option.  The strategy is - on ostree systems, set the flag
`__$ROLENAME_is_ostree` if the system is an ostree system.  The flag
will either be undefined or `false` on non-ostree systems.
Then, change every invocation of the `package:` module like this:

```yaml
- name: Ensure required packages are present
  package:
    name: "{{ __$ROLENAME_packages }}"
    state: present
    use: "{{ (__$ROLENAME_is_ostree | d(false)) |
      ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
```

This should ensure that the `use:` parameter is not used if the system
is non-ostree.  The goal is to make the ostree support as unobtrusive
as possible for non-ostree systems.
The user can also set `__$ROLENAME_is_ostree: true` in the inventory or play
if the user knows that ostree is being used and wants to skip the check.
Or, the user is concerned about the performance hit for ostree detection
on non-ostree systems, and sets `__$ROLENAME_is_ostree: false` to skip
the check.
The flag `__$ROLENAME_is_ostree` can also be used in the role or tests to
include or exclude tasks from being run on ostree systems.

This fix also improves error reporting in the `get_ostree_data.sh` script
when included roles cannot be found.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
