### PR TITLE
ci: fix ansible-lint 2.16 and ansible-test 2.16 issues

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -24,5 +24,7 @@ mock_modules:
   - win_domain_group
   - win_domain_user
   - community.general.ini_file
+  - ansible.windows.win_command
+  - ansible.windows.win_shell
 mock_roles:
   - linux-system-roles.ad_integration

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,3 +1,4 @@
+---
 # Default state for all rules
 default: true
 


### PR DESCRIPTION
ci: fix ansible-lint 2.16 and ansible-test 2.16 issues
Signed-off-by: Rich Megginson <rmeggins@redhat.com>
