### PR TITLE
feat: add ad_integration_preserve_authselect_profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,13 @@ ad_integration_sssd_custom_settings:
     value: "configuration_value"
 ```
 
+#### ad_integration_preserve_authselect_profile
+
+This is a boolean, default is `false`.  If `true`, configure realmd.conf to
+remove the `authselect` command from `sssd-enable-logins` to avoid overwriting
+previous PAM/nsswitch changes, until
+[RHEL-5101](https://issues.redhat.com/browse/RHEL-5101) is addressed.
+
 ## Example Playbook
 
 The following is an example playbook to setup direct Active Directory integration with AD domain `domain.example.com`, the join will be performed with user Administrator using the vault stored password. Prior to the join, the crypto policy for AD SUPPORT with RC4 encryption allowed will be set.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -142,3 +142,8 @@ ad_integration_sssd_settings: []
 # - key: "configuration_name"
 #   value: "configuration_value"
 ad_integration_sssd_custom_settings: []
+
+# If `true`, configure realmd.conf to remove the `authselect` command from
+# `sssd-enable-logins` to avoid overwriting previous PAM/nsswitch changes, until
+# https://issues.redhat.com/browse/RHEL-5101 is addressed.
+ad_integration_preserve_authselect_profile: false

--- a/templates/realmd.conf.j2
+++ b/templates/realmd.conf.j2
@@ -10,3 +10,8 @@ automatic-id-mapping = {{ ad_integration_auto_id_mapping }}
 {% if ad_integration_computer_ou %}
 computer-ou = {{ ad_integration_computer_ou }}
 {% endif %}
+{% if ad_integration_preserve_authselect_profile %}
+[commands]
+sssd-enable-logins = /usr/bin/sh -c "/usr/bin/systemctl enable oddjobd.service && /usr/bin/systemctl start oddjobd.service"
+sssd-disable-logins = /bin/true
+{% endif %}


### PR DESCRIPTION
Feature: Add ad_integration_preserve_authselect_profile as a boolean
parameter.

Reason: Users need to be able to remove the `authselect` command from
`sssd-enable-logins` to avoid overwriting previous PAM/nsswitch changes,
until [RHEL-5101](https://issues.redhat.com/browse/RHEL-5101) is addressed.

Result: Users can use the ad_integration role with PAM/nsswitch changes.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
