### PR TITLE
ci: Add a basic test for ad_integration_preserve_authselect_profile

### DIFF
--- a/tests/tests_preserve_authselect.yml
+++ b/tests/tests_preserve_authselect.yml
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Ensure that the role ad_integration_preserve_authselect_profile works
+  hosts: all,!ad
+  gather_facts: false  # test that role works in this case
+  vars:
+    # sample realm that will skip joining realm step
+    ad_integration_realm: "{{ __ad_integration_sample_realm }}"
+    ad_integration_password: Secret123
+    ad_integration_preserve_authselect_profile: true
+
+  tasks:
+    - name: Test - Run the system role
+      include_role:
+        name: linux-system-roles.ad_integration
+
+    - name: Test - Check that realmd config is present
+      stat:
+        path: /etc/realmd.conf
+      register: __stat_result
+      failed_when: not __stat_result.stat.exists
+      changed_when: false
+
+    - name: Get realmd.conf
+      slurp:
+        path: /etc/realmd.conf
+      register: realmd_conf_raw
+
+    - name: Decode realmd.conf
+      set_fact:
+        realmd_conf: "{{ realmd_conf_raw.content | b64decode }}"
+
+    - name: Test - Check that expected strings are in realmd.conf
+      assert:
+        that:
+          - "'sssd-enable-logins = /usr/bin/sh' in realmd_conf"
+          - "'sssd-disable-logins = /bin/true' in realmd_conf"


### PR DESCRIPTION
Enhancement:
Add a basic test for the new functionality ad_integration_preserve_authselect_profile.
