### PR TITLE
fix: Add default_ipv4 to required_facts to gather ansible_hostname

### DIFF
--- a/tests/tests_dyndns.yml
+++ b/tests/tests_dyndns.yml
@@ -19,6 +19,7 @@
 
 - name: Ensure that the role configures dynamic dns
   hosts: all,!ad
+  gather_facts: false
   vars:
     # if we don't have a real AD server, just verify the config
     # file is written properly

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -17,6 +17,7 @@ __ad_integration_required_facts:
   - distribution_major_version
   - distribution_version
   - os_family
+  - default_ipv4
 # the subsets of ansible_facts that need to be gathered in case any of the
 # facts in required_facts is missing; see the documentation of
 # the 'gather_subset' parameter of the 'setup' module


### PR DESCRIPTION
Enhancement: Add default_ipv4 to required_facts to gather ansible_hostname fact

Reason: The role didn't gather ansible_hostname but used it in tasks/main.yml

Result: The bug is fixed
