### PR TITLE
fix: Sets domain name lower case in realmd.conf section header

### DIFF
--- a/templates/realmd.conf.j2
+++ b/templates/realmd.conf.j2
@@ -5,7 +5,7 @@
 [active-directory]
 default-client = {{ ad_integration_client_software }}
 
-[{{ ad_integration_realm }}]
+[{{ ad_integration_realm | lower }}]
 automatic-id-mapping = {{ ad_integration_auto_id_mapping }}
 {% if ad_integration_computer_ou %}
 computer-ou = {{ ad_integration_computer_ou }}


### PR DESCRIPTION
Enhancement: Set domain name lower case in realmd.conf section header

Reason: Realm specific sections should always contain the domain name in lower case as their section header.