### PR TITLE
test: Replace deprecated community.windows.win_domain_user and group modules

### DIFF
--- a/tests/collection-requirements.yml
+++ b/tests/collection-requirements.yml
@@ -3,4 +3,4 @@
 collections:
   - community.windows
   - ansible.windows
-  - community.general
+  - microsoft.ad

--- a/tests/tests_full_integration.yml
+++ b/tests/tests_full_integration.yml
@@ -26,8 +26,8 @@
 - name: Prepare user and groups on the AD
   hosts: ad
   tasks:
-    - name: Create groups
-      win_domain_group:
+    - name: Create groups  # noqa syntax-check[unknown-module]
+      microsoft.ad.group:
         name: "{{ item.name }}"
         state: present
         scope: "{{ item.scope }}"
@@ -40,7 +40,7 @@
         var: group_creation
 
     - name: Add a test user
-      win_domain_user:
+      microsoft.ad.user:  # noqa syntax-check[unknown-module]
         name: "{{ item.name }}"
         firstname: "{{ item.first_name }}"
         surname: "{{ item.surname }}"

--- a/tests/tests_full_integration_dc.yml
+++ b/tests/tests_full_integration_dc.yml
@@ -34,8 +34,8 @@
 - name: Prepare user and groups on the AD
   hosts: ad
   tasks:
-    - name: Create groups
-      win_domain_group:
+    - name: Create groups  # noqa syntax-check[unknown-module]
+      microsoft.ad.group:
         name: "{{ item.name }}"
         state: present
         scope: "{{ item.scope }}"
@@ -48,7 +48,7 @@
         var: group_creation
 
     - name: Add a test user
-      win_domain_user:
+      microsoft.ad.user:  # noqa syntax-check[unknown-module]
         name: "{{ item.name }}"
         firstname: "{{ item.first_name }}"
         surname: "{{ item.surname }}"

--- a/tests/tests_full_integration_force_rejoin.yml
+++ b/tests/tests_full_integration_force_rejoin.yml
@@ -29,8 +29,8 @@
 - name: Prepare user and groups on the AD
   hosts: ad
   tasks:
-    - name: Create groups
-      win_domain_group:
+    - name: Create groups  # noqa syntax-check[unknown-module]
+      microsoft.ad.group:
         name: "{{ item.name }}"
         state: present
         scope: "{{ item.scope }}"
@@ -43,7 +43,7 @@
         var: group_creation
 
     - name: Add a test user
-      win_domain_user:
+      microsoft.ad.user:  # noqa syntax-check[unknown-module]
         name: "{{ item.name }}"
         firstname: "{{ item.first_name }}"
         surname: "{{ item.surname }}"


### PR DESCRIPTION
Enhancement: Replace deprecated `community.windows.win_domain_user` and `group` modules

Reason: `community.windows.win_domain_group` and `community.windows.win_domain_user` has been deprecated

Result: Tests use `microsoft.ad.group` and `microsoft.ad.user` instead
