### PR TITLE
tests: Fix invocation of the `microsoft.ad.user` module

### DIFF
--- a/tests/tests_full_integration.yml
+++ b/tests/tests_full_integration.yml
@@ -41,16 +41,16 @@
 
     - name: Add a test user
       microsoft.ad.user:  # noqa syntax-check[unknown-module]
-        name: "{{ item.name }}"
-        firstname: "{{ item.first_name }}"
-        surname: "{{ item.surname }}"
+        identity: test_usr1
+        firstname: Josef
+        surname: Novak
         password: Secret123
         state: present
         groups:
-          - test_grp1
-      loop:
-        - {name: 'test_usr1', first_name: 'Josef', surname: 'Novak'}
+          set:
+            - test_grp1
       register: user_creation
+
     - name: Debug user_creation
       debug:
         var: user_creation

--- a/tests/tests_full_integration_dc.yml
+++ b/tests/tests_full_integration_dc.yml
@@ -49,15 +49,14 @@
 
     - name: Add a test user
       microsoft.ad.user:  # noqa syntax-check[unknown-module]
-        name: "{{ item.name }}"
-        firstname: "{{ item.first_name }}"
-        surname: "{{ item.surname }}"
+        identity: test_usr1
+        firstname: Josef
+        surname: Novak
         password: Secret123
         state: present
         groups:
-          - test_grp1
-      loop:
-        - {name: 'test_usr1', first_name: 'Josef', surname: 'Novak'}
+          set:
+            - test_grp1
       register: user_creation
     - name: Debug user_creation
       debug:

--- a/tests/tests_full_integration_force_rejoin.yml
+++ b/tests/tests_full_integration_force_rejoin.yml
@@ -44,16 +44,16 @@
 
     - name: Add a test user
       microsoft.ad.user:  # noqa syntax-check[unknown-module]
-        name: "{{ item.name }}"
-        firstname: "{{ item.first_name }}"
-        surname: "{{ item.surname }}"
+        identity: test_usr1
+        firstname: Josef
+        surname: Novak
         password: Secret123
         state: present
         groups:
-          - test_grp1
-      loop:
-        - {name: 'test_usr1', first_name: 'Josef', surname: 'Novak'}
+          set:
+            - test_grp1
       register: user_creation
+
     - name: Debug user_creation
       debug:
         var: user_creation


### PR DESCRIPTION
Enhancement: Fix invocation of the `microsoft.ad.user` module

Reason: #91 replaced community.windows.win_domain_user with microsoft.ad.user but new module has a different API.