### PR TITLE
Add realm permit and deny

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -147,3 +147,18 @@ ad_integration_sssd_custom_settings: []
 # `sssd-enable-logins` to avoid overwriting previous PAM/nsswitch changes, until
 # https://issues.redhat.com/browse/RHEL-5101 is addressed.
 ad_integration_preserve_authselect_profile: false
+
+# Optional. A list of AD users that are permitted to log into the system
+# Requires a space seperated list
+# ad_integration_permit_groups: Admin developer sales@domain.com
+ad_integration_permit_groups: null
+
+# Optional. A list of AD groups that are permitted to log into the system
+# Requires a space seperated list
+# ad_integration_permit_users: foo@domain.com bar@domain.com DOMAIN.COM\baz
+ad_integration_permit_users: null
+
+# Optional. if true, will run `realm deny --all`
+# realm: Specifying deny without --all is deprecated. Use realm permit --withdraw
+# Only applicable if `ad_integration_permit_groups` and `ad_intergration_permit_users` are false
+ad_integration_deny: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -47,6 +47,17 @@
     - (ad_integration_dns_server is none or
        ad_integration_dns_connection_name is none or
        ad_integration_dns_connection_type is none)
+# Validate deny and permit variables
+- name: Ensure deny and permit varables are not set together 
+  fail:
+    msg: >-
+      ad_integration_permit_groups, ad_integration_permit_users cannot be defined
+      alongside ad_integration_deny
+  when:
+    - (ad_integration_permit_users is not none or
+       ad_integration_permit_groups is not none and
+       ad_integration_deny is true)
+
 
 - name: Set platform/version specific variables
   include_tasks: tasks/set_vars.yml


### PR DESCRIPTION
Enhancement:
Adding realm permit and deny functionality
Reason:
Gives full control over realm of Linux machines

Issue Tracker Tickets (Jira or BZ if any): #110 
