### PR TITLE
ci: Use Fedora 41, drop Fedora 39

### DIFF
--- a/.github/workflows/tft.yml
+++ b/.github/workflows/tft.yml
@@ -98,9 +98,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - platform: Fedora-39
-            ansible_version: 2.17
           - platform: Fedora-40
+            ansible_version: 2.17
+          - platform: Fedora-41
             ansible_version: 2.17
           - platform: CentOS-7-latest
             ansible_version: 2.9


### PR DESCRIPTION
Fedora 41 is released, and Fedora 39 will soon be unsupported

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
