### PR TITLE
ci: Update dyndns test for Fedora 42 and RHEL 10

### DIFF
--- a/tests/tests_full_integration_dyndns.yml
+++ b/tests/tests_full_integration_dyndns.yml
@@ -62,6 +62,7 @@
 
 - name: Ensure that the role configures dynamic dns
   hosts: client
+  gather_facts: true
   tasks:
     - name: Run the integration
       when: "'ad' in groups and groups['ad']"
@@ -69,14 +70,14 @@
         - name: Debug dyndns settings
           debug:
             msg: >-
-              Interface {{ _ad_dyndns_iface | default('eth0') }} and server
+              Interface {{ _ad_dyndns_iface | default(ansible_default_ipv4.interface) }} and server
               : {{ hostvars[groups['ad'][0]].ansible_host }}
         - name: Run the system role with proper config
           include_role:
             name: linux-system-roles.ad_integration
           vars:
             ad_dyndns_server: "{{ hostvars[groups['ad'][0]].ansible_host }}"
-            ad_dyndns_iface: "{{ _ad_dyndns_iface | default('eth0') }}"
+            ad_dyndns_iface: "{{ _ad_dyndns_iface | default(ansible_default_ipv4.interface) }}"
             ad_dyndns_auth: "none"
             ad_dyndns_update: true
             ad_dyndns_refresh_interval: 60


### PR DESCRIPTION
Enhancement:
Dyndns test needs to detect network interface name to work properly. Instead of defaulting to eth0 we use real name for the test.

Reason:
The test was no longer working with Fedora 42 and RHEL 10.0

## Summary by Sourcery

Update the dyndns integration test to automatically detect the network interface instead of defaulting to 'eth0' for compatibility with Fedora 42 and RHEL 10.

Enhancements:
- Use ansible_default_ipv4.interface as the default dyndns interface in tests instead of hardcoding 'eth0'.

Tests:
- Adjust the full integration dyndns test playbook to leverage dynamic interface detection.