### PR TITLE
feat: search for name of domain/realm in sssd.conf; merge settings if duplicates

### DIFF
--- a/.ostree/packages-testing.txt
+++ b/.ostree/packages-testing.txt
@@ -1,0 +1,1 @@
+sssd-common

--- a/.sanity-ansible-ignore-2.14.txt
+++ b/.sanity-ansible-ignore-2.14.txt
@@ -1,0 +1,1 @@
+tests/ad_integration/templates/fake_realm.py.j2 shebang!skip

--- a/.sanity-ansible-ignore-2.15.txt
+++ b/.sanity-ansible-ignore-2.15.txt
@@ -1,0 +1,1 @@
+tests/ad_integration/templates/fake_realm.py.j2 shebang!skip

--- a/.sanity-ansible-ignore-2.16.txt
+++ b/.sanity-ansible-ignore-2.16.txt
@@ -1,0 +1,1 @@
+tests/ad_integration/templates/fake_realm.py.j2 shebang!skip

--- a/.sanity-ansible-ignore-2.17.txt
+++ b/.sanity-ansible-ignore-2.17.txt
@@ -1,0 +1,1 @@
+tests/ad_integration/templates/fake_realm.py.j2 shebang!skip

--- a/.sanity-ansible-ignore-2.18.txt
+++ b/.sanity-ansible-ignore-2.18.txt
@@ -1,0 +1,1 @@
+tests/ad_integration/templates/fake_realm.py.j2 shebang!skip

--- a/.sanity-ansible-ignore-2.19.txt
+++ b/.sanity-ansible-ignore-2.19.txt
@@ -1,0 +1,1 @@
+tests/ad_integration/templates/fake_realm.py.j2 shebang!skip

--- a/.sanity-ansible-ignore-2.9.txt
+++ b/.sanity-ansible-ignore-2.9.txt
@@ -1,0 +1,1 @@
+tests/ad_integration/templates/fake_realm.py.j2 shebang!skip

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ Administrator user as the security footprint of this user is too large.
 See [Delegated Permissions](https://www.mankier.com/8/adcli#Delegated_Permissions)
 for the explicit permissions a user must have.
 
-Time must be in sync with Active Directory servers. The ad_integration role will use the timesync system role for this if the user specifies `ad_integration_manage_timesync` to true and provides a value for `ad_integration_timesync_source` to use as a timesource.
+Time must be in sync with Active Directory servers. The ad_integration role will use the timesync system role for this if the user specifies [ad_integration_manage_timesync](#ad_integration_manage_timesync) to true and provides a value for [ad_integration_timesync_source](#ad_integration_timesync_source) to use as a timesource.
 
-RHEL8 (and newer) and Fedora no longer support RC4 encryption out of the box, it is recommended to enable AES in Active Directory, if not possible then the AD-SUPPORT crypto policy must be enabled.  The integration role will use the crypto_policies system role for this if the user sets the `ad_integration_manage_crypto_policies` and `ad_integration_allow_rc4_crypto` parameters to true.
+RHEL8 (and newer) and Fedora no longer support RC4 encryption out of the box, it is recommended to enable AES in Active Directory, if not possible then the AD-SUPPORT crypto policy must be enabled.  The integration role will use the crypto_policies system role for this if the user sets the [ad_integration_manage_crypto_policies](ad_integration_manage_crypto_policies) and [ad_integration_allow_rc4_crypto](#ad_integration_allow_rc4_crypto) parameters to true.
 
 The Linux system must be able to resolve default AD DNS SRV records.
 
@@ -54,6 +54,22 @@ ansible-galaxy collection install -vv -r meta/collection-requirements.yml
 #### ad_integration_realm
 
 Active Directory realm, or domain name to join
+
+*NOTE* If using this role to manage realm/domain specific settings in SSSD using
+([ad_dyndns_update](#ad_dyndns_update) or
+[ad_integration_sssd_custom_settings](#ad_integration_sssd_custom_settings),
+older versions of the role would make the realm name lower case in the domain
+section name.  For example, if you had specified `ad_integration_realm:
+EXAMPLE.COM`, then the sssd.conf section would have been `[domain/example.com]`.
+The role now will instead use a case-insensitive match to look for an existing
+section in sssd.conf, which should already exist.
+
+The result of this is that you may have multiple sections for the domain in your
+sssd.conf. If you want to consolidate these sections into one, use
+[`ad_integration_sssd_merge_duplicate_sections:
+true`](#ad_integration_sssd_merge_duplicate_sections).  See below for more
+information about
+[ad_integration_sssd_merge_duplicate_sections(#ad_integration_sssd_merge_duplicate_sections).
 
 #### ad_integration_password
 
@@ -105,13 +121,13 @@ Default: Default AD computer container
 
 #### ad_integration_manage_timesync
 
-If true, the ad_integration role will use fedora.linux_system_roles.timesync. Requires providing a value for `ad_integration_timesync_source` to use as a time source.
+If true, the ad_integration role will use fedora.linux_system_roles.timesync. Requires providing a value for [ad_integration_timesync_source](#ad_integration_timesync_source) to use as a time source.
 
 Default: false
 
 #### ad_integration_timesync_source
 
-Hostname or IP address of time source to synchronize the system clock with. Providing this variable automatically sets `ad_integration_manage_timesync` to true.
+Hostname or IP address of time source to synchronize the system clock with. Providing this variable automatically sets [ad_integration_manage_timesync](#ad_integration_manage_timesync) to true.
 
 #### ad_integration_manage_crypto_policies
 
@@ -121,7 +137,7 @@ Default: false
 
 #### ad_integration_allow_rc4_crypto
 
-If true, the ad_integration role will set the crypto policy allowing RC4 encryption. Providing this variable automatically sets ad_integration_manage_crypto_policies to true
+If true, the ad_integration role will set the crypto policy allowing RC4 encryption. Providing this variable automatically sets [ad_integration_manage_crypto_policies](#ad_integration_manage_crypto_policies) to true
 
 Default: false
 
@@ -135,25 +151,29 @@ If true, the ad_integration role will use fedora.linux_system_roles.network to a
 
 #### ad_integration_dns_server
 
-IP address of DNS server to add to existing networking configuration. Only applicable if `ad_integration_manage_dns` is true
+IP address of DNS server to add to existing networking configuration. Only applicable if [ad_integration_manage_dns](#ad_integration_manage_dns) is true
 
 #### ad_integration_dns_connection_name
 
-The name option identifies the connection profile to be configured by the network role. It is not the name of the networking interface for which the profile applies. Only applicable if `ad_integration_manage_dns` is true
+The name option identifies the connection profile to be configured by the network role. It is not the name of the networking interface for which the profile applies. Only applicable if [ad_integration_manage_dns](#ad_integration_manage_dns) is true
 
 #### ad_integration_dns_connection_type
 
-Network connection type such as ethernet, bridge, bond...etc, the network role contains a list of possible values. Only applicable if `ad_integration_manage_dns` is true
+Network connection type such as ethernet, bridge, bond...etc, the network role contains a list of possible values. Only applicable if [ad_integration_manage_dns](#ad_integration_manage_dns) is true
 
 #### ad_dyndns_update
 
 If true, SSSD is configured to automatically update the AD DNS server with the IP address of the client.
 
+*NOTE*: See the [ad_integration_realm](#ad_integration_realm), and
+[ad_integration_sssd_merge_duplicate_sections](#ad_integration_sssd_merge_duplicate_sections)
+for information about how the role writes these settings to the sssd.conf file.
+
 Default: false
 
 #### ad_dyndns_ttl
 
-Optional. The TTL, in seconds, to apply to the client's DNS record when updating it. Only applicable if `ad_dyndns_update` is true
+Optional. The TTL, in seconds, to apply to the client's DNS record when updating it. Only applicable if [ad_dyndns_update](#ad_dyndns_update) is true
 
 **Note:** This will override the TTL set by an administrator on the server.
 
@@ -161,13 +181,13 @@ Default: 3600
 
 #### ad_dyndns_iface
 
-Optional. Interface or a list of interfaces whose IP addresses should be used for dynamic DNS updates. Special value "*" implies all IPs from all interfaces should be used. Only applicable if `ad_dyndns_update` is true
+Optional. Interface or a list of interfaces whose IP addresses should be used for dynamic DNS updates. Special value "*" implies all IPs from all interfaces should be used. Only applicable if [ad_dyndns_update](#ad_dyndns_update) is true
 
 Default: Use the IP addresses of the interface which is used for AD LDAP connection
 
 #### ad_dyndns_refresh_interval
 
-Optional. How often should, in seconds, periodic DNS updates be performed in addition to when the back end goes online. Only applicable if `ad_dyndns_update` is true
+Optional. How often should, in seconds, periodic DNS updates be performed in addition to when the back end goes online. Only applicable if [ad_dyndns_update](#ad_dyndns_update) is true
 
 **Note:** lowest possible value is 60 seconds. If value less than 60 is specified sssd will assume lowest value only.
 
@@ -175,34 +195,34 @@ Default: 86400
 
 #### ad_dyndns_update_ptr
 
-Optional. If true, the PTR record should also be explicitly updated. Only applicable if `ad_dyndns_update` is true
+Optional. If true, the PTR record should also be explicitly updated. Only applicable if [ad_dyndns_update](#ad_dyndns_update) is true
 
 Default: true
 
 #### ad_dyndns_force_tcp
 
-Optional. If true, the nsupdate utility should default to using TCP for communicating with the DNS server. Only applicable if `ad_dyndns_update` is true
+Optional. If true, the nsupdate utility should default to using TCP for communicating with the DNS server. Only applicable if [ad_dyndns_update](#ad_dyndns_update) is true
 
 Default: false
 
 #### ad_dyndns_auth
 
-Optional. If true, GSS-TSIG authentication will be used for secure updates with the DNS server when updating A and AAAA records. Only applicable if `ad_dyndns_update` is true
+Optional. If true, GSS-TSIG authentication will be used for secure updates with the DNS server when updating A and AAAA records. Only applicable if [ad_dyndns_update](#ad_dyndns_update) is true
 
 Default: true
 
 #### ad_dyndns_server
 
-Optional. DNS server to use when performing a DNS update when autodetection settings fail. Only applicable if `ad_dyndns_update` is true
+Optional. DNS server to use when performing a DNS update when autodetection settings fail. Only applicable if [ad_dyndns_update](#ad_dyndns_update) is true
 
 Default: None (let nsupdate choose the server)
 
 #### ad_integration_join_parameters
 
 Additional parameters (as a string) supplied directly to the realm join command.
-Useful if some specific configuration like --user-principal=host/name@REALM or --use-ldaps is needed.
+Useful if some specific configuration like `--user-principal=host/name@REALM` or `--use-ldaps` is needed.
 See man realm for details.
-Example: ad_integration_join_parameters: "--user-principal host/client007@EXAMPLE.COM"
+Example: `ad_integration_join_parameters: "--user-principal host/client007@EXAMPLE.COM"`
 
 #### ad_integration_sssd_settings
 
@@ -228,6 +248,10 @@ ad_integration_sssd_custom_settings:
     value: "configuration_value"
 ```
 
+*NOTE*: See the [ad_integration_realm](#ad_integration_realm) and
+[ad_integration_sssd_merge_duplicate_sections](#ad_integration_sssd_merge_duplicate_sections) for information about how the
+role writes these settings to the sssd.conf file.
+
 #### ad_integration_preserve_authselect_profile
 
 This is a boolean, default is `false`.  If `true`, configure realmd.conf to
@@ -240,6 +264,30 @@ previous PAM/nsswitch changes, until
 By default, the role installs OS‐level packages needed for Active Directory integration. If `false`, the role assumes that all prerequisites are already in place and skips package installation.
 
 Default: true
+
+#### ad_integration_sssd_merge_duplicate_sections
+
+*NOTE WELL*: This will do a [force rejoin](#ad_integration_force_rejoin) as this
+is the only way to clean up sssd.conf and ensure all of the settings are applied
+correctly after merging.
+
+This is a boolean, default is `false`.  Because the domain/realm section in
+sssd.conf is case insensitive, and you have previously used the role to manage
+domain/realm settings in sssd.conf, there may be multiple sections matching the
+domain/realm.  If you want to consolidate these sections into one, use
+`ad_integration_sssd_merge_duplicate_sections: true`.  For example, if you have
+a sssd.conf with both `[domain/example.com]` and `[domain/EXAMPLE.COM]`, and you
+want to use only the latter, then use:
+
+```yaml
+ad_integration_realm: EXAMPLE.COM
+ad_integration_sssd_merge_duplicate_sections: true
+ad_integration_sssd_custom_settings: somesettings
+```
+
+All of the settings from `[domain/example.com]` will be moved to
+`[domain/EXAMPLE.COM]`, and the section `[domain/example.com]` will be removed
+from sssd.conf.
 
 ## Example Playbook
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -150,3 +150,8 @@ ad_integration_preserve_authselect_profile: false
 
 # Set to false to skip the package installation task.
 ad_integration_manage_packages: true
+
+# There may be duplicate sections for the realm in sssd.conf - if you set this
+# to true, then the role will consolidate the data from those duplicate sections
+# and remove the duplicate sections
+ad_integration_sssd_merge_duplicate_sections: false

--- a/filter_plugins/ad_integration_from_ini.py
+++ b/filter_plugins/ad_integration_from_ini.py
@@ -1,0 +1,109 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2023, Steffen Scheib <steffen@scheib.me>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+DOCUMENTATION = r"""
+name: from_ini
+short_description: Converts INI text input into a dictionary
+version_added: 8.2.0
+author: Steffen Scheib (@sscheib)
+description:
+  - Converts INI text input into a dictionary.
+options:
+  _input:
+    description: A string containing an INI document.
+    type: string
+    required: true
+"""
+
+EXAMPLES = r"""
+- name: Slurp an INI file
+  ansible.builtin.slurp:
+    src: /etc/rhsm/rhsm.conf
+  register: rhsm_conf
+
+- name: Display the INI file as dictionary
+  ansible.builtin.debug:
+    var: rhsm_conf.content | b64decode | community.general.from_ini
+
+- name: Set a new dictionary fact with the contents of the INI file
+  ansible.builtin.set_fact:
+    rhsm_dict: >-
+      {{
+          rhsm_conf.content | b64decode | community.general.from_ini
+      }}
+"""
+
+RETURN = r"""
+_value:
+  description: A dictionary representing the INI file.
+  type: dictionary
+"""
+
+import sys
+
+from ansible.errors import AnsibleFilterError
+from ansible.module_utils.six import string_types
+from ansible.module_utils.six.moves import StringIO
+
+if sys.version_info.major == 3:
+    from ansible.module_utils.six.moves.configparser import ConfigParser
+else:
+    # use RawConfigParser because it uses interpolation=None
+    from ConfigParser import RawConfigParser as ConfigParser
+
+
+class IniParser(ConfigParser):
+    """Implements a configparser which is able to return a dict"""
+
+    def __init__(self):
+        if sys.version_info.major == 2:
+            ConfigParser.__init__(self)
+        else:
+            super().__init__(interpolation=None)
+        self.optionxform = str
+
+    def as_dict(self):
+        d = dict(self._sections)
+        for k in d:
+            d[k] = dict(self._defaults, **d[k])
+            d[k].pop("__name__", None)
+
+        if self._defaults:
+            d["DEFAULT"] = dict(self._defaults)
+
+        return d
+
+    def my_read_file(self, fp):
+        if sys.version_info.major == 2:
+            self.readfp(fp)
+        else:
+            self.read_file(fp)
+
+
+def from_ini(obj):
+    """Read the given string as INI file and return a dict"""
+
+    if not isinstance(obj, string_types):
+        raise AnsibleFilterError("from_ini requires a str, got %s" % type(obj))
+
+    parser = IniParser()
+
+    try:
+        parser.my_read_file(StringIO(obj))
+    except Exception as ex:
+        raise AnsibleFilterError(
+            "from_ini failed to parse given string: %s" % str(ex), orig_exc=ex
+        )
+
+    return parser.as_dict()
+
+
+class FilterModule(object):
+    """Query filter"""
+
+    def filters(self):
+
+        return {"ad_integration_from_ini": from_ini}

--- a/filter_plugins/ad_integration_from_ini.yml
+++ b/filter_plugins/ad_integration_from_ini.yml
@@ -1,0 +1,35 @@
+DESCRIPTION:
+  name: ad_integration_from_ini
+  short_description: Converts INI text input into a dictionary
+  version_added: 8.2.0
+  author: Steffen Scheib (@sscheib)
+  description:
+    - Converts INI text input into a dictionary.
+    - Copied from community.general in order to support ansible 2.9
+  options:
+    _input:
+      description: A string containing an INI document.
+      type: string
+      required: true
+
+EXAMPLES: |
+  - name: Slurp an INI file
+    ansible.builtin.slurp:
+      src: /etc/rhsm/rhsm.conf
+    register: rhsm_conf
+
+  - name: Display the INI file as dictionary
+    ansible.builtin.debug:
+      var: rhsm_conf.content | b64decode | community.general.from_ini
+
+  - name: Set a new dictionary fact with the contents of the INI file
+    ansible.builtin.set_fact:
+      rhsm_dict: >-
+        {{
+            rhsm_conf.content | b64decode | community.general.from_ini
+        }}
+
+RETURN:
+  _value:
+    description: A dictionary representing the INI file.
+    type: dictionary

--- a/lsr_role2coll_extra_script
+++ b/lsr_role2coll_extra_script
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+if [ -n "${LSR_DEBUG:-}" ]; then
+  set -x
+fi
+
+# if it's already fqcn, don't replace it
+fqcn="$LSR_NAMESPACE.$LSR_COLLECTION.ad_integration_from_ini"
+find tasks templates -type f \
+  -exec sed -i "s/\([ 	]\)ad_integration_from_ini\>/\1$fqcn/g" \
+  {} \;

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -126,30 +126,84 @@
     - ansible_distribution in ['CentOS', 'RedHat']
     - ansible_distribution_version is version('9', '>=')
 
+- name: Grab existing domain settings from sssd.conf if we want to merge
+  when: ad_integration_sssd_merge_duplicate_sections | bool
+  vars:
+    __ad_sssd_conf: "{{ __ad_sssd_conf_content.content | b64decode | ad_integration_from_ini
+      if __ad_sssd_conf_content.content is defined else {} }}"
+    __ad_sssd_section: domain/{{ ad_integration_realm }}
+  block:
+    - name: See if sssd.conf exists
+      stat:
+        path: "{{ __ad_integration_sssd_conf }}"
+      register: __ad_sssd_conf_stat
+
+    - name: Grab sssd.conf if it exists
+      slurp:
+        path: "{{ __ad_integration_sssd_conf }}"
+      register: __ad_sssd_conf_content
+      when: __ad_sssd_conf_stat.stat.exists
+      no_log: true
+
+    - name: Set variables we will need for merging - 1
+      set_fact:
+        __ad_integration_matching_sections_before: "{{ __ad_sssd_conf | dict2items | selectattr('key', 'match', '(?i)' ~ __ad_sssd_section ~ '$') |
+          list | items2dict }}"
+      no_log: true
+
+    - name: Set variables we will need for merging - 2
+      set_fact:
+        __ad_integration_has_duplicates: "{{ __ad_integration_matching_sections_before | length > 1 }}"
+      no_log: true
+
 ## Handle rejoin, if applicable
 - name: Check if we are already joined to a domain
-  command: realm -v list
+  command: "{{ __ad_integration_realm_cmd | quote }} -v list"
   register: __ad_integration_realm_list
   changed_when: false
-  when: ad_integration_force_rejoin | bool
+  when: ad_integration_force_rejoin | bool or __ad_integration_has_duplicates | d(false)
 
+# NOTE: This will remove the [domain/realm] section from sssd.conf - if there
+# are multiple such sections, it is unknown which one will be removed
 - name: Leave existing joined domain
-  command: realm -v leave
+  command: "{{ __ad_integration_realm_cmd | quote }} -v leave"
   when:
-    - ad_integration_force_rejoin | bool
+    - ad_integration_force_rejoin | bool or __ad_integration_has_duplicates | d(false)
     - '"domain-name" in __ad_integration_realm_list.stdout'
     - not ansible_check_mode
   changed_when: true
 
+- name: Remove any duplicate domain sections after realm leave
+  when: __ad_integration_has_duplicates | d(false)
+  vars:
+    __ad_matching_section_names: "{{ __ad_integration_matching_sections_before | d({}) | dict2items | map(attribute='key') | list }}"
+  block:
+    - name: See if sssd.conf exists after realm leave
+      stat:
+        path: "{{ __ad_integration_sssd_conf }}"
+      register: __ad_sssd_conf_stat
+
+    - name: Remove duplicate sections
+      community.general.ini_file:
+        path: "{{ __ad_integration_sssd_conf }}"
+        state: absent
+        section: "{{ item }}"
+        owner: root
+        group: root
+        mode: u=rw,g=,o=
+      loop: "{{ __ad_matching_section_names }}"
+      when: __ad_sssd_conf_stat.stat.exists
+      notify: Handler for ad_integration to restart services - sssd
+
 - name: Build Command - Join to a specific Domain Controller
   set_fact:
     __ad_integration_join_command: >-
-      realm join -U {{ ad_integration_user | quote }} --membership-software
+      {{ __ad_integration_realm_cmd | quote }} join -U {{ ad_integration_user | quote }} --membership-software
       {{ ad_integration_membership_software | quote }}
       {{ ad_integration_join_parameters }}
       {{ ad_integration_join_to_dc | quote }}
     __ad_integration_debug_command: >-
-      realm join -U {{ ad_integration_user | quote }} --membership-software
+      {{ __ad_integration_realm_cmd | quote }} join -U {{ ad_integration_user | quote }} --membership-software
       {{ ad_integration_membership_software | quote }}
       {{ ad_integration_join_to_dc | quote }}
   no_log: true
@@ -158,12 +212,12 @@
 - name: Build Join Command - Perform discovery-based realm join operation
   set_fact:
     __ad_integration_join_command: >-
-      realm join -U {{ ad_integration_user | quote }} --membership-software
+      {{ __ad_integration_realm_cmd | quote }} join -U {{ ad_integration_user | quote }} --membership-software
       {{ ad_integration_membership_software | quote }}
       {{ ad_integration_join_parameters }}
       {{ ad_integration_realm | quote }}
     __ad_integration_debug_command: >-
-      realm join -U {{ ad_integration_user | quote }} --membership-software
+      {{ __ad_integration_realm_cmd | quote }} join -U {{ ad_integration_user | quote }} --membership-software
       {{ ad_integration_membership_software | quote }}
       {{ ad_integration_realm | quote }}
   no_log: true
@@ -199,94 +253,140 @@
   changed_when: not __realm_join_output.stderr is
     search("Already joined to this domain")
 
-- name: Configure SSSD settings
-  community.general.ini_file:
-    path: /etc/sssd/sssd.conf
-    state: "{{ item.state | default('present') }}"
-    section: "sssd"
-    option: "{{ item.key }}"
-    value: "{{ item.value }}"
-    create: true
-    owner: root
-    group: root
-    mode: u=rw,g=,o=
-  loop: "{{ ad_integration_sssd_settings }}"
-  notify: Handler for ad_integration to restart services - sssd
+- name: Handle any SSSD settings
+  when: ad_integration_sssd_settings | length > 0 or
+    ad_dyndns_update or ad_integration_sssd_custom_settings | length > 0 or
+    __ad_integration_matching_sections_before | d({}) | length > 0
+  vars:
+    __ad_sssd_conf: "{{ __ad_sssd_conf_content.content | b64decode | ad_integration_from_ini
+      if __ad_sssd_conf_content.content is defined else {} }}"
+    __ad_sssd_section: domain/{{ ad_integration_realm }}
+    __ad_matching_section_names: "{{ __ad_sssd_conf | dict2items | selectattr('key', 'match', '(?i)' ~ __ad_sssd_section ~ '$') |
+      map(attribute='key') | list }}"
+    __ad_matching_section_names_exact: "{{ __ad_sssd_conf | dict2items | selectattr('key', 'match', __ad_sssd_section ~ '$') |
+      map(attribute='key') | list }}"
+    # if there is a unique match using a case-insensitive match, use it
+    # otherwise, if there is an exact case-sensitive match, use it
+    # otherwise, just use the first one found in the case-insensitive match
+    __ad_section_to_use: "{{ __ad_matching_section_names | first
+      if __ad_matching_section_names | length == 1
+      else __ad_matching_section_names_exact | first
+      if __ad_matching_section_names_exact | length == 1
+      else __ad_matching_section_names | first }}"
+  block:
+    - name: See if sssd.conf exists after realm join
+      stat:
+        path: "{{ __ad_integration_sssd_conf }}"
+      register: __ad_sssd_conf_stat
 
-- name: Configure dynamic DNS updates
-  community.general.ini_file:
-    path: /etc/sssd/sssd.conf
-    state: present
-    section: "domain/{{ ad_integration_realm | lower }}"
-    option: "{{ item.key }}"
-    value: "{{ item.value }}"
-    create: true
-    owner: root
-    group: root
-    mode: u=rw,g=,o=
-  loop:
-    - key: dyndns_update
-      value: "{{ ad_dyndns_update | string }}"
-    - key: dyndns_ttl
-      value: "{{ ad_dyndns_ttl | int }}"
-    - key: dyndns_iface
-      value: "{{ ad_dyndns_iface | string
-        if ad_dyndns_iface is not none else '' }}"
-    - key: dyndns_refresh_interval
-      value: "{{ ad_dyndns_refresh_interval | int }}"
-    - key: dyndns_update_ptr
-      value: "{{ ad_dyndns_update_ptr | string }}"
-    - key: dyndns_force_tcp
-      value: "{{ ad_dyndns_force_tcp | string }}"
-    - key: dyndns_auth
-      value: "{{ ad_dyndns_auth | string if ad_dyndns_auth else '' }}"
-    - key: dyndns_server
-      value: "{{ ad_dyndns_server | string
-        if ad_dyndns_server is not none else '' }}"
-    # For dynamic dns to work the machine either needs fqdn in hostname
-    # or ad_hostname needs to be defined.
-    - key: ad_hostname
-      value: "{{ ansible_hostname + '.' + ad_integration_realm | lower
-        | string if '.' not in ansible_hostname else '' }}"
+    - name: Grab sssd.conf if it exists after realm join
+      slurp:
+        path: "{{ __ad_integration_sssd_conf }}"
+      register: __ad_sssd_conf_content
+      when: __ad_sssd_conf_stat.stat.exists
 
-  when:
-    - ad_dyndns_update | bool
-    - item.value is not none
-    - item.value != ''
-  notify: Handler for ad_integration to restart services - sssd
+    - name: Consolidate options from duplicate sections
+      community.general.ini_file:
+        path: "{{ __ad_integration_sssd_conf }}"
+        state: present
+        section: "{{ __ad_section_to_use }}"
+        option: "{{ item.key }}"
+        value: "{{ item.value }}"
+        create: true
+        owner: root
+        group: root
+        mode: u=rw,g=,o=
+      loop: "{{ (__ad_integration_matching_sections_before | d({})).values() | map('dict2items') | flatten | list }}"
+      notify: Handler for ad_integration to restart services - sssd
+      when: ad_integration_sssd_merge_duplicate_sections | bool
 
-- name: Configure custom SSSD settings
-  community.general.ini_file:
-    path: /etc/sssd/sssd.conf
-    state: "{{ item.state | default('present') }}"
-    section: "domain/{{ ad_integration_realm | lower }}"
-    option: "{{ item.key }}"
-    value: "{{ item.value }}"
-    create: true
-    owner: root
-    group: root
-    mode: u=rw,g=,o=
-  loop: "{{ ad_integration_sssd_custom_settings }}"
-  notify: Handler for ad_integration to restart services - sssd
+    - name: Configure SSSD settings
+      community.general.ini_file:
+        path: "{{ __ad_integration_sssd_conf }}"
+        state: "{{ item.state | default('present') }}"
+        section: sssd
+        option: "{{ item.key }}"
+        value: "{{ item.value }}"
+        create: true
+        owner: root
+        group: root
+        mode: u=rw,g=,o=
+      loop: "{{ ad_integration_sssd_settings }}"
+      notify: Handler for ad_integration to restart services - sssd
 
-# If dyndns_iface and/or dyndns_server previously had a configured value but are
-# now being set to `none` or `''`, remove the options form sssd.conf so sssd
-# will determine the default values.
-- name: Cleanup dynamic DNS configuration options
-  community.general.ini_file:
-    path: /etc/sssd/sssd.conf
-    state: absent
-    section: "domain/{{ ad_integration_realm | lower }}"
-    option: "{{ item.key }}"
-    owner: root
-    group: root
-    mode: u=rw,g=,o=
-  loop:
-    - key: dyndns_iface
-      value: "{{ '' if ad_dyndns_iface is none else ad_dyndns_iface }}"
-    - key: dyndns_server
-      value: "{{ '' if ad_dyndns_server is none else ad_dyndns_server }}"
-  when:
-    - ad_dyndns_update | bool
-    - item.value is none or item.value == ''
-  notify: Handler for ad_integration to restart services - sssd
+    - name: Configure dynamic DNS updates
+      community.general.ini_file:
+        path: "{{ __ad_integration_sssd_conf }}"
+        state: present
+        section: "{{ __ad_section_to_use }}"
+        option: "{{ item.key }}"
+        value: "{{ item.value }}"
+        create: true
+        owner: root
+        group: root
+        mode: u=rw,g=,o=
+      loop:
+        - key: dyndns_update
+          value: "{{ ad_dyndns_update | string }}"
+        - key: dyndns_ttl
+          value: "{{ ad_dyndns_ttl | int }}"
+        - key: dyndns_iface
+          value: "{{ ad_dyndns_iface | string
+            if ad_dyndns_iface is not none else '' }}"
+        - key: dyndns_refresh_interval
+          value: "{{ ad_dyndns_refresh_interval | int }}"
+        - key: dyndns_update_ptr
+          value: "{{ ad_dyndns_update_ptr | string }}"
+        - key: dyndns_force_tcp
+          value: "{{ ad_dyndns_force_tcp | string }}"
+        - key: dyndns_auth
+          value: "{{ ad_dyndns_auth | string if ad_dyndns_auth else '' }}"
+        - key: dyndns_server
+          value: "{{ ad_dyndns_server | string
+            if ad_dyndns_server is not none else '' }}"
+        # For dynamic dns to work the machine either needs fqdn in hostname
+        # or ad_hostname needs to be defined.
+        - key: ad_hostname
+          value: "{{ ansible_hostname + '.' + ad_integration_realm | lower
+            | string if '.' not in ansible_hostname else '' }}"
+      when:
+        - ad_dyndns_update | bool
+        - item.value is not none
+        - item.value != ''
+      notify: Handler for ad_integration to restart services - sssd
+
+    - name: Configure custom SSSD settings
+      community.general.ini_file:
+        path: "{{ __ad_integration_sssd_conf }}"
+        state: "{{ item.state | default('present') }}"
+        section: "{{ __ad_section_to_use }}"
+        option: "{{ item.key }}"
+        value: "{{ item.value }}"
+        create: true
+        owner: root
+        group: root
+        mode: u=rw,g=,o=
+      loop: "{{ ad_integration_sssd_custom_settings }}"
+      notify: Handler for ad_integration to restart services - sssd
+
+    # If dyndns_iface and/or dyndns_server previously had a configured value but are
+    # now being set to `none` or `''`, remove the options form sssd.conf so sssd
+    # will determine the default values.
+    - name: Cleanup dynamic DNS configuration options
+      community.general.ini_file:
+        path: "{{ __ad_integration_sssd_conf }}"
+        state: absent
+        section: "{{ __ad_section_to_use }}"
+        option: "{{ item.key }}"
+        owner: root
+        group: root
+        mode: u=rw,g=,o=
+      loop:
+        - key: dyndns_iface
+          value: "{{ '' if ad_dyndns_iface is none else ad_dyndns_iface }}"
+        - key: dyndns_server
+          value: "{{ '' if ad_dyndns_server is none else ad_dyndns_server }}"
+      when:
+        - ad_dyndns_update | bool
+        - item.value is none or item.value == ''
+      notify: Handler for ad_integration to restart services - sssd

--- a/tests/roles/linux-system-roles.ad_integration/filter_plugins
+++ b/tests/roles/linux-system-roles.ad_integration/filter_plugins
@@ -1,0 +1,1 @@
+../../../filter_plugins

--- a/tests/tasks/check_header.yml
+++ b/tests/tasks/check_header.yml
@@ -8,8 +8,8 @@
 - name: Check for presence of ansible managed header, fingerprint
   assert:
     that:
-      - ansible_managed in content
+      - __ansible_managed in content
       - __fingerprint in content
   vars:
     content: "{{ __content.content | b64decode }}"
-    ansible_managed: "{{ lookup('template', 'get_ansible_managed.j2') }}"
+    __ansible_managed: "{{ lookup('template', 'get_ansible_managed.j2') }}"

--- a/tests/tasks/manage_fake_realm.yml
+++ b/tests/tasks/manage_fake_realm.yml
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Setup
+  when: __manage_fake_realm == "setup"
+  block:
+    - name: Get role variables
+      include_role:
+        name: linux-system-roles.ad_integration
+        tasks_from: set_vars.yml
+        public: true
+
+    - name: Create a temp file for fake realm cmd
+      tempfile:
+        prefix: lsr_
+        suffix: _ad_int_realm.py
+      register: __fake_realm_tmp
+
+    - name: Set realm cmd variable for remainder of test
+      set_fact:
+        __ad_integration_realm_cmd: "{{ __fake_realm_tmp.path }}"
+
+    - name: Create fake realm cmd
+      template:
+        src: templates/fake_realm.py.j2
+        dest: "{{ __fake_realm_tmp.path }}"
+        mode: "0755"
+
+    - name: Check if /etc/sssd exists
+      stat:
+        path: /etc/sssd
+      register: __sssd_dir_stat
+
+    - name: Install sssd-common for /etc/sssd
+      package:
+        name: sssd-common
+        state: present
+        use: "{{ (__ad_integration_is_ostree | d(false)) |
+                 ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
+      when: not __sssd_dir_stat.stat.exists
+      register: __installed_sssd_package
+
+- name: Cleanup
+  when: __manage_fake_realm == "cleanup"
+  block:
+    - name: Remove realm cmd
+      file:
+        path: "{{ __ad_integration_realm_cmd }}"
+        state: absent
+
+    - name: Remove sssd-common
+      package:
+        name: sssd-common
+        state: absent
+      when:
+        - not __ad_integration_is_ostree
+        - __installed_sssd_package is changed

--- a/tests/templates/fake_realm.py.j2
+++ b/tests/templates/fake_realm.py.j2
@@ -1,0 +1,59 @@
+#!{{ ansible_python.executable }}
+import argparse
+import os
+import sys
+
+if sys.version_info.major == 3:
+    from configparser import RawConfigParser as ConfigParser
+else:
+    from ConfigParser import RawConfigParser as ConfigParser
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-v", action="store_true")
+    subparsers = parser.add_subparsers(dest="subcmd_name")
+    parser_list = subparsers.add_parser("list")
+    parser_leave = subparsers.add_parser("leave")
+    parser_join = subparsers.add_parser("join")
+    parser_join.add_argument("-U", "--user")
+    parser_join.add_argument("--membership-software")
+    parser_join.add_argument("realm")
+    return parser.parse_args()
+
+sssd_conf = "{{ __ad_integration_sssd_conf }}"
+args = parse_args()
+
+realm = getattr(args, "realm", "{{ ad_integration_realm }}")
+section = "domain/" + realm
+section_lower = section.lower()
+if "{{ __ad_integration_realm_to_lower | d('false') }}".lower() == "true":
+    section_to_add = section_lower
+else:
+    section_to_add = section
+
+conf = ConfigParser()
+conf.read(sssd_conf)
+
+if args.subcmd_name == "list":
+    print("{{ __ad_integration_realm_list | d('') }}")
+elif args.subcmd_name == "leave":
+    # When leaving, if there are duplicate sections, we don't
+    # know which one will be removed - just remove the first
+    for existing_section in conf.sections():
+        if section_lower == existing_section.lower():
+            conf.remove_section(existing_section)
+            with open(sssd_conf, "w") as fp:
+                conf.write(fp)
+            break
+elif args.subcmd_name == "join":
+    if not conf.has_section(section_to_add):
+        conf.add_section(section_to_add)
+        conf.set(section_to_add, "ad_domain", "{{ ad_integration_realm }}")
+        conf.set(section_to_add, "id_provider", "ad")
+        with open(sssd_conf, "w") as fp:
+            conf.write(fp)
+    else:
+        print("realm: Already joined to this domain")
+
+sys.exit(0)

--- a/tests/tests_dyndns.yml
+++ b/tests/tests_dyndns.yml
@@ -19,7 +19,7 @@
 
 - name: Ensure that the role configures dynamic dns
   hosts: all,!ad
-  gather_facts: false
+  gather_facts: true
   vars:
     # if we don't have a real AD server, just verify the config
     # file is written properly
@@ -27,108 +27,124 @@
       ansible_play_hosts_all | length == 1 }}"
     # note - value from inventory such as described above
     # will override this value
-    ad_integration_realm: sample-realm.com
+    ad_integration_realm: dyndns-sample-realm.com
   tasks:
-    - name: Test - Run the system role with bogus vars
-      include_role:
-        name: linux-system-roles.ad_integration
-      vars:
-        ad_dyndns_iface: TESTING
-        ad_dyndns_server: 127.0.0.1
-        ad_dyndns_auth: GSS-TSIG
-        ad_dyndns_update: true
-
-    - name: Check custom dyndns settings
-      community.general.ini_file:
-        path: /etc/sssd/sssd.conf
-        state: present
-        section: domain/{{ ad_integration_realm | lower }}
-        option: "{{ item.key }}"
-        value: "{{ item.value }}"
-        create: true
-        owner: root
-        group: root
-        mode: u=rw,g=,o=
-      loop:
-        - key: dyndns_update
-          value: "True"
-        - key: dyndns_iface
-          value: TESTING
-        - key: dyndns_auth
-          value: GSS-TSIG
-        - key: dyndns_server
-          value: 127.0.0.1
-      register: __result
-      failed_when: __result is changed
-
-    - name: Search /var/log/sssd/sssd.log for [sss_ini_call_validators]
-      command: grep -i sss_ini_call_validators /var/log/sssd/sssd.log
-      register: sssd_log
-      changed_when: false
-      failed_when: false
-
-    - name: Fail if signature found
-      fail:
-        msg: Appears to be an unsupported option in /etc/sssd/sssd.conf
-      when: sssd_log.stdout | length > 0
-
-    - name: Test - Re-run the system role to remove vars
-      include_role:
-        name: linux-system-roles.ad_integration
-      vars:
-        ad_dyndns_iface: null
-        ad_dyndns_server: null
-        ad_dyndns_update: true
-
-    - name: Restart sssd
-      service:
-        name: sssd
-        state: restarted
-      when: not __ad_integration_test_sssd_config_only | d(false)
-
-    - name: Check custom dyndns settings are removed
-      community.general.ini_file:
-        path: /etc/sssd/sssd.conf
-        state: absent
-        section: domain/{{ ad_integration_realm | lower }}
-        option: "{{ item.key }}"
-        create: true
-        owner: root
-        group: root
-        mode: u=rw,g=,o=
-      loop:
-        - key: dyndns_iface
-          value: null
-        - key: dyndns_server
-          value: null
-      register: __result
-      failed_when: __result is changed
-
-    - name: Test - Verify IPv4 DNS records were created
-      when: not __ad_integration_test_sssd_config_only | d(false)
+    - name: Run test
       block:
-        - name: Gather facts
-          setup:
+        - name: Setup fake realm
+          include_tasks: tasks/manage_fake_realm.yml
+          vars:
+            __manage_fake_realm: setup
+          when: __ad_integration_test_sssd_config_only
 
-        # I am executing dig via shell instead of using the dig lookup because
-        # in my situation my ansible control host is on a different network and
-        # DNS than the VMs I am testing against.
-        - name: Get IP for host's FQDN
-          command: dig +short {{ ansible_fqdn }} A
-          register: dig_hostname
+        - name: Test - Run the system role with bogus vars
+          include_role:
+            name: linux-system-roles.ad_integration
+            public: true
+          vars:
+            ad_dyndns_iface: TESTING
+            ad_dyndns_server: 127.0.0.1
+            ad_dyndns_auth: GSS-TSIG
+            ad_dyndns_update: true
+
+        - name: Check custom dyndns settings
+          community.general.ini_file:
+            path: "{{ __ad_integration_sssd_conf }}"
+            state: present
+            section: domain/{{ ad_integration_realm }}
+            option: "{{ item.key }}"
+            value: "{{ item.value }}"
+            create: true
+            owner: root
+            group: root
+            mode: u=rw,g=,o=
+          loop:
+            - key: dyndns_update
+              value: "True"
+            - key: dyndns_iface
+              value: TESTING
+            - key: dyndns_auth
+              value: GSS-TSIG
+            - key: dyndns_server
+              value: 127.0.0.1
+          register: __result
+          failed_when: __result is changed
+
+        - name: Search /var/log/sssd/sssd.log for [sss_ini_call_validators]
+          command: grep -i sss_ini_call_validators /var/log/sssd/sssd.log
+          register: sssd_log
           changed_when: false
           failed_when: false
 
-        - name: Get hostname for host's IP address
-          command: dig +short -x {{ ansible_default_ipv4.address }} PTR
-          register: dig_ip
-          changed_when: false
-          failed_when: false
+        - name: Fail if signature found
+          fail:
+            msg: Appears to be an unsupported option in /etc/sssd/sssd.conf
+          when: sssd_log.stdout | length > 0
 
-        - name: Assert IPv4 DNS records were created
-          assert:
-            that:
-              - "'{{ dig_hostname.stdout }}' ==
-                '{{ ansible_default_ipv4.address }}'"
-              - "'{{ dig_ip.stdout }}' == '{{ ansible_fqdn }}.'"
-          when: ansible_default_ipv4.address is defined
+        - name: Test - Re-run the system role to remove vars
+          include_role:
+            name: linux-system-roles.ad_integration
+          vars:
+            ad_dyndns_iface: null
+            ad_dyndns_server: null
+            ad_dyndns_update: true
+
+        - name: Restart sssd
+          service:
+            name: sssd
+            state: restarted
+          when: not __ad_integration_test_sssd_config_only | d(false)
+
+        - name: Check custom dyndns settings are removed
+          community.general.ini_file:
+            path: "{{ __ad_integration_sssd_conf }}"
+            state: absent
+            section: domain/{{ ad_integration_realm }}
+            option: "{{ item.key }}"
+            create: true
+            owner: root
+            group: root
+            mode: u=rw,g=,o=
+          loop:
+            - key: dyndns_iface
+              value: null
+            - key: dyndns_server
+              value: null
+          register: __result
+          failed_when: __result is changed
+
+        - name: Test - Verify IPv4 DNS records were created
+          when: not __ad_integration_test_sssd_config_only | d(false)
+          block:
+            - name: Gather facts
+              setup:
+
+            # I am executing dig via shell instead of using the dig lookup because
+            # in my situation my ansible control host is on a different network and
+            # DNS than the VMs I am testing against.
+            - name: Get IP for host's FQDN
+              command: dig +short {{ ansible_fqdn }} A
+              register: dig_hostname
+              changed_when: false
+              failed_when: false
+
+            - name: Get hostname for host's IP address
+              command: dig +short -x {{ ansible_default_ipv4.address }} PTR
+              register: dig_ip
+              changed_when: false
+              failed_when: false
+
+            - name: Assert IPv4 DNS records were created
+              assert:
+                that:
+                  - "'{{ dig_hostname.stdout }}' ==
+                    '{{ ansible_default_ipv4.address }}'"
+                  - "'{{ dig_ip.stdout }}' == '{{ ansible_fqdn }}.'"
+              when: ansible_default_ipv4.address is defined
+
+      always:
+        - name: Cleanup fake realm
+          include_tasks: tasks/manage_fake_realm.yml
+          vars:
+            __manage_fake_realm: cleanup
+          when: __ad_integration_test_sssd_config_only

--- a/tests/tests_full_integration.yml
+++ b/tests/tests_full_integration.yml
@@ -64,7 +64,9 @@
         - name: Test run the system role
           include_role:
             name: linux-system-roles.ad_integration
+            public: true
           register: role_run
+
         - name: Debug role_run
           debug:
             var: role_run
@@ -75,7 +77,7 @@
             state: restarted
 
         - name: Test sssd config contains the realm
-          command: 'cat /etc/sssd/sssd.conf'
+          command: cat {{ __ad_integration_sssd_conf | quote }}
           register: sssd_config
           failed_when: '"{{ ad_integration_realm }}" not in sssd_config.stdout'
           changed_when: false

--- a/tests/tests_full_integration_dc.yml
+++ b/tests/tests_full_integration_dc.yml
@@ -71,7 +71,9 @@
         - name: Test run the system role
           include_role:
             name: linux-system-roles.ad_integration
+            public: true
           register: role_run
+
         - name: Debug role_run
           debug:
             var: role_run
@@ -82,7 +84,7 @@
             state: restarted
 
         - name: Test sssd config contains the realm
-          command: 'cat /etc/sssd/sssd.conf'
+          command: cat {{ __ad_integration_sssd_conf | quote }}
           register: sssd_config
           failed_when: '"{{ ad_integration_realm }}" not in sssd_config.stdout'
           changed_when: false

--- a/tests/tests_full_integration_dyndns.yml
+++ b/tests/tests_full_integration_dyndns.yml
@@ -75,6 +75,7 @@
         - name: Run the system role with proper config
           include_role:
             name: linux-system-roles.ad_integration
+            public: true
           vars:
             ad_dyndns_server: "{{ hostvars[groups['ad'][0]].ansible_host }}"
             ad_dyndns_iface: "{{ _ad_dyndns_iface | default(ansible_default_ipv4.interface) }}"
@@ -103,7 +104,7 @@
           changed_when: false
           failed_when: false
         - name: Grab sssd.conf contents
-          command: cat /etc/sssd/sssd.conf
+          command: cat {{ __ad_integration_sssd_conf | quote }}
           changed_when: false
         - name: Get IP for host's FQDN
           command: >-

--- a/tests/tests_full_integration_force_rejoin.yml
+++ b/tests/tests_full_integration_force_rejoin.yml
@@ -67,7 +67,9 @@
         - name: Test run the system role
           include_role:
             name: linux-system-roles.ad_integration
+            public: true
           register: role_run
+
         - name: Debug role_run
           debug:
             var: role_run
@@ -78,7 +80,7 @@
             state: restarted
 
         - name: Test sssd config contains the realm - before rejoin
-          command: cat /etc/sssd/sssd.conf
+          command: cat {{ __ad_integration_sssd_conf | quote }}
           register: sssd_config
           failed_when: ad_integration_realm not in sssd_config.stdout
           changed_when: false
@@ -121,7 +123,7 @@
           changed_when: false
 
         - name: Test sssd config contains the realm - after rejoin
-          command: cat /etc/sssd/sssd.conf
+          command: cat {{ __ad_integration_sssd_conf | quote }}
           register: sssd_config
           failed_when: ad_integration_realm not in sssd_config.stdout
           changed_when: false

--- a/tests/tests_migrate_sssd_settings.yml
+++ b/tests/tests_migrate_sssd_settings.yml
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Ensure that the role migrates sssd domain settings depending on case
+  hosts: all,!ad
+  gather_facts: true
+  vars:
+    ad_integration_realm: MIGRATE.REALM.COM
+    __ad_integration_test_sssd_config_only: true
+    __ad_integration_sssd_custom_settings:
+      - key: setting_1_1
+        value: value_1_1
+      - key: setting_1_2
+        value: value_1_2
+    __ad_integration_sssd_custom_settings2:
+      - key: setting_2_1
+        value: value_2_1
+      - key: setting_2_2
+        value: value_2_2
+    __ad_integration_sssd_custom_settings3:
+      - key: setting_3_1
+        value: value_3_1
+      - key: setting_3_2
+        value: value_3_2
+    __sssd_conf_content: |
+      [domain/{{ ad_integration_realm | lower }}]
+      {% for item in __ad_integration_sssd_custom_settings %}
+      # comment {{ loop.index }}
+      {{ item["key"] }} = {{ item["value"] }}
+      {% endfor %}
+      [domain/{{ ad_integration_realm }}]
+      {% for item in __ad_integration_sssd_custom_settings2 %}
+      # comment {{ loop.index }}
+      {{ item["key"] }} = {{ item["value"] }}
+      {% endfor %}
+  tasks:
+    - name: Run test
+      block:
+        - name: Create a temp file for sssd.conf
+          tempfile:
+            prefix: lsr_
+            suffix: _ad_int.conf
+          register: __sssd_conf_tmp
+
+        - name: Set sssd.conf variable for remainder of test
+          set_fact:
+            __ad_integration_sssd_conf: "{{ __sssd_conf_tmp.path }}"
+
+        - name: Create a fake sssd.conf
+          copy:
+            dest: "{{ __ad_integration_sssd_conf }}"
+            content: "{{ __sssd_conf_content }}"
+            mode: "0600"
+
+        - name: Setup fake realm
+          include_tasks: tasks/manage_fake_realm.yml
+          vars:
+            __manage_fake_realm: setup
+            __ad_integration_realm_list: "domain-name: {{ ad_integration_realm }}"
+
+        - name: Test - Run the system role merging duplicate sssd domain sections
+          include_role:
+            name: linux-system-roles.ad_integration
+          vars:
+            ad_integration_sssd_custom_settings: "{{ __ad_integration_sssd_custom_settings +
+              __ad_integration_sssd_custom_settings2 + __ad_integration_sssd_custom_settings3 }}"
+            ad_integration_sssd_merge_duplicate_sections: true
+
+        - name: Check custom SSSD settings - this section should be removed
+          community.general.ini_file:
+            path: "{{ __ad_integration_sssd_conf }}"
+            state: absent
+            section: domain/{{ ad_integration_realm | lower }}
+            create: true
+            owner: root
+            group: root
+            mode: u=rw,g=,o=
+          register: __result
+          failed_when: __result is changed
+
+        - name: Check custom SSSD settings again - for merged options
+          community.general.ini_file:
+            path: "{{ __ad_integration_sssd_conf }}"
+            state: "{{ item.state | default('present') }}"
+            section: domain/{{ ad_integration_realm }}
+            option: "{{ item.key }}"
+            value: "{{ item.value }}"
+            create: true
+            owner: root
+            group: root
+            mode: u=rw,g=,o=
+          loop: "{{ __ad_integration_sssd_custom_settings +
+            __ad_integration_sssd_custom_settings2 + __ad_integration_sssd_custom_settings3 }}"
+          register: __result
+          failed_when: __result is changed
+
+      always:
+        - name: Cleanup fake realm
+          include_tasks: tasks/manage_fake_realm.yml
+          vars:
+            __manage_fake_realm: cleanup

--- a/tests/tests_sssd_custom_settings.yml
+++ b/tests/tests_sssd_custom_settings.yml
@@ -3,9 +3,9 @@
 
 - name: Ensure that the role configures dynamic dns
   hosts: all,!ad
-  gather_facts: false  # test that role works in this case
+  gather_facts: true
   vars:
-    ad_integration_realm: sample-realm.com
+    ad_integration_realm: sssd-custom-sample-realm.com
     __ad_integration_test_sssd_config_only: true
     ad_integration_sssd_custom_settings:
       - key: auth_provider_test
@@ -14,59 +14,73 @@
         value: /bin/bash
 
   tasks:
-    - name: Test - Run the system role with bogus vars
-      include_role:
-        name: linux-system-roles.ad_integration
+    - name: Run test
+      block:
+        - name: Setup fake realm
+          include_tasks: tasks/manage_fake_realm.yml
+          vars:
+            __manage_fake_realm: setup
 
-    - name: Check custom SSSD settings
-      community.general.ini_file:
-        path: /etc/sssd/sssd.conf
-        state: "{{ item.state | default('present') }}"
-        section: domain/{{ ad_integration_realm | lower }}
-        option: "{{ item.key }}"
-        value: "{{ item.value }}"
-        create: true
-        owner: root
-        group: root
-        mode: u=rw,g=,o=
-      loop: "{{ ad_integration_sssd_custom_settings }}"
-      register: __result
-      failed_when: __result is changed
+        - name: Test - Run the system role with bogus vars
+          include_role:
+            name: linux-system-roles.ad_integration
+            public: true
 
-    - name: Search /var/log/sssd/sssd.log for [sss_ini_call_validators]
-      command: >-
-        grep -i sss_ini_call_validators /var/log/sssd/sssd.log
-      register: sssd_log
-      changed_when: false
-      failed_when: false
+        - name: Check custom SSSD settings
+          community.general.ini_file:
+            path: "{{ __ad_integration_sssd_conf }}"
+            state: "{{ item.state | default('present') }}"
+            section: domain/{{ ad_integration_realm }}
+            option: "{{ item.key }}"
+            value: "{{ item.value }}"
+            create: true
+            owner: root
+            group: root
+            mode: u=rw,g=,o=
+          loop: "{{ ad_integration_sssd_custom_settings }}"
+          register: __result
+          failed_when: __result is changed
 
-    - name: Fail if signature found
-      fail:
-        msg: Appears to be an unsupported option in /etc/sssd/sssd.conf
-      when: sssd_log.stdout | length > 0
+        - name: Search /var/log/sssd/sssd.log for [sss_ini_call_validators]
+          command: >-
+            grep -i sss_ini_call_validators /var/log/sssd/sssd.log
+          register: sssd_log
+          changed_when: false
+          failed_when: false
 
-    - name: Test - Re-Build a list of settings with state=absent
-      set_fact:
-        update_list: "{{ ad_integration_sssd_custom_settings |
-          map('combine', {'state': 'absent'}) | list }}"
+        - name: Fail if signature found
+          fail:
+            msg: Appears to be an unsupported option in /etc/sssd/sssd.conf
+          when: sssd_log.stdout | length > 0
 
-    - name: Test - Re-run the system role to remove vars
-      include_role:
-        name: linux-system-roles.ad_integration
-      vars:
-        ad_integration_sssd_custom_settings: "{{ update_list }}"
+        - name: Test - Re-Build a list of settings with state=absent
+          set_fact:
+            update_list: "{{ ad_integration_sssd_custom_settings |
+              map('combine', {'state': 'absent'}) | list }}"
 
-    - name: Check custom SSSD settings
-      community.general.ini_file:
-        path: /etc/sssd/sssd.conf
-        state: "{{ item.state | default('present') }}"
-        section: domain/{{ ad_integration_realm | lower }}
-        option: "{{ item.key }}"
-        value: "{{ item.value }}"
-        create: true
-        owner: root
-        group: root
-        mode: u=rw,g=,o=
-      loop: "{{ update_list }}"
-      register: __result
-      failed_when: __result is changed
+        - name: Test - Re-run the system role to remove vars
+          include_role:
+            name: linux-system-roles.ad_integration
+          vars:
+            ad_integration_sssd_custom_settings: "{{ update_list }}"
+
+        - name: Check custom SSSD settings after removing vars
+          community.general.ini_file:
+            path: "{{ __ad_integration_sssd_conf }}"
+            state: "{{ item.state | default('present') }}"
+            section: domain/{{ ad_integration_realm }}
+            option: "{{ item.key }}"
+            value: "{{ item.value }}"
+            create: true
+            owner: root
+            group: root
+            mode: u=rw,g=,o=
+          loop: "{{ update_list }}"
+          register: __result
+          failed_when: __result is changed
+
+      always:
+        - name: Cleanup fake realm
+          include_tasks: tasks/manage_fake_realm.yml
+          vars:
+            __manage_fake_realm: cleanup

--- a/tests/tests_sssd_settings.yml
+++ b/tests/tests_sssd_settings.yml
@@ -17,10 +17,11 @@
     - name: Test - Run the system role with bogus vars
       include_role:
         name: linux-system-roles.ad_integration
+        public: true
 
     - name: Check SSSD settings
       community.general.ini_file:
-        path: /etc/sssd/sssd.conf
+        path: "{{ __ad_integration_sssd_conf }}"
         state: "{{ item.state | default('present') }}"
         section: sssd
         option: "{{ item.key }}"
@@ -58,7 +59,7 @@
 
     - name: Check custom SSSD settings
       community.general.ini_file:
-        path: /etc/sssd/sssd.conf
+        path: "{{ __ad_integration_sssd_conf }}"
         state: "{{ item.state | default('present') }}"
         section: sssd
         option: "{{ item.key }}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -27,6 +27,10 @@ __ad_integration_required_facts_subsets: "{{ ['!all', '!min'] +
 __ad_integration_sample_realm: sample-realm.com
 # Sample dc server used for system tests without available real AD
 __ad_integration_sample_dc: sample-dc.sample-realm.com
+# path to sssd.conf file
+__ad_integration_sssd_conf: /etc/sssd/sssd.conf
+# realm command
+__ad_integration_realm_cmd: realm
 
 # BEGIN - DO NOT EDIT THIS BLOCK - rh distros variables
 # Ansible distribution identifiers that the role treats like RHEL


### PR DESCRIPTION
Feature: Search for the name of the section used in the SSSD config file
for the domain/realm specific settings, as managed by `ad_dyndns_update` and
`ad_integration_sssd_custom_settings`.  This section is added by `realm join`
and the casing of the name is determined by AD settings, so we need to search
for the name using a case insensitive search.
Previous versions of the role would always use a lower case realm in the section
name, which may have left the SSSD config file with multiple sections
for the realm.  Use the new `ad_integration_sssd_merge_duplicate_sections` setting
to consolidate all of the settings from the multiple sections into the chosen
section.

Reason: The realm/domain section in the SSSD config file is written by
`realm join`, and the case is determined by AD settings, so we must do a search
to find the section name to use for writting additional SSSD realm/domain
settings.  In addition, we need some way to clean up any previously
duplicated settings from the SSSD config.

Result: The ad_integration role can manage domain/realm sections in the SSSD
config file correctly.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>