### PR TITLE
refactor: comply with Ansible partner certification checks [citest_skip]

### DIFF
--- a/.sanity-ansible-ignore-2.20.txt
+++ b/.sanity-ansible-ignore-2.20.txt
@@ -1,0 +1,1 @@
+tests/ad_integration/templates/fake_realm.py.j2 shebang!skip

--- a/.sanity-ansible-ignore-2.21.txt
+++ b/.sanity-ansible-ignore-2.21.txt
@@ -1,0 +1,1 @@
+tests/ad_integration/templates/fake_realm.py.j2 shebang!skip

--- a/filter_plugins/ad_integration_from_ini.yml
+++ b/filter_plugins/ad_integration_from_ini.yml
@@ -1,3 +1,4 @@
+---
 DESCRIPTION:
   name: ad_integration_from_ini
   short_description: Converts INI text input into a dictionary


### PR DESCRIPTION
https://github.com/ansible-collections/partner-certification-checker/blob/main/README.md

Ensure that our code complies with these policies/checks and prepare for
improved ansible-lint and ansible-test checks.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Add Ansible metadata to the AD integration filter plugin and introduce version-specific sanity ignore configuration files to align with Ansible partner certification checks.

Enhancements:
- Document the AD integration INI-to-dictionary filter plugin with Ansible-compliant metadata headers.

CI:
- Add Ansible sanity ignore configuration files for Ansible 2.20 and 2.21 to satisfy updated partner certification and linting requirements.