### PR TITLE
test: support ansible-test milestone version 2.22 [citest_skip]

### DIFF
--- a/.sanity-ansible-ignore-2.22.txt
+++ b/.sanity-ansible-ignore-2.22.txt
@@ -1,0 +1,1 @@
+tests/ad_integration/templates/fake_realm.py.j2 shebang!skip

--- a/filter_plugins/ad_integration_from_ini.py
+++ b/filter_plugins/ad_integration_from_ini.py
@@ -45,7 +45,6 @@ _value:
 import sys
 
 from ansible.errors import AnsibleFilterError
-from ansible.module_utils.six import string_types
 from ansible.module_utils.six.moves import StringIO
 
 if sys.version_info.major == 3:
@@ -53,6 +52,11 @@ if sys.version_info.major == 3:
 else:
     # use RawConfigParser because it uses interpolation=None
     from ConfigParser import RawConfigParser as ConfigParser
+
+try:
+    lsr_string_types = (basestring,)
+except NameError:
+    lsr_string_types = (str,)
 
 
 class IniParser(ConfigParser):
@@ -86,7 +90,7 @@ class IniParser(ConfigParser):
 def from_ini(obj):
     """Read the given string as INI file and return a dict"""
 
-    if not isinstance(obj, string_types):
+    if not isinstance(obj, lsr_string_types):
         raise AnsibleFilterError("from_ini requires a str, got %s" % type(obj))
 
     parser = IniParser()


### PR DESCRIPTION
The ansible milestone branch is now version 2.22

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Update AD integration INI filter to use an internal string type helper compatible with current ansible-test milestone and add the corresponding ansible sanity ignore file for version 2.22.

Bug Fixes:
- Fix type checking in the from_ini filter by replacing deprecated ansible.module_utils.six string_types with a local, version-agnostic string type tuple.

Chores:
- Add ansible sanity ignore configuration file for milestone version 2.22.