### PR TITLE
test: add role fingerprints to syslog

### DIFF
--- a/tests/tests_sssd_settings.yml
+++ b/tests/tests_sssd_settings.yml
@@ -13,9 +13,15 @@
         value: addomain.xyz
 
   tasks:
+    - name: See if /dev/log exists for the fingerprint check
+      stat:
+        path: /dev/log
+      register: __register_dev_log
+
     - name: Set the start time for the journal search
       set_fact:
         __journal_start_time: "{{ ansible_facts['date_time']['date'] ~ ' ' ~ ansible_facts['date_time']['time'] }}"
+      when: __register_dev_log.stat.exists
 
     - name: Test - Run the system role with bogus vars
       include_tasks: tasks/run_role_with_clear_facts.yml
@@ -24,15 +30,18 @@
 
     # look for the exact module invocation, not some other message that might contain the string
     - name: Check system journal contains role fingerprints
-      shell: >-
-        set -eo pipefail;
-        journalctl --since "{{ __journal_start_time }}" --no-pager |
-        grep -v " Invoked with" | grep "sr_fingerprint.*begin system_role:ad_integration" ||
-        { echo ERROR: BEGIN fingerprint not found; exit 1; };
-        journalctl --since "{{ __journal_start_time }}" --no-pager |
-        grep -v " Invoked with" | grep "sr_fingerprint.*success system_role:ad_integration" ||
-        { echo ERROR: SUCCESS fingerprint not found; exit 1; }
+      shell:
+        executable: /bin/bash
+        cmd: >-
+          set -eo pipefail;
+          journalctl --since "{{ __journal_start_time }}" --no-pager |
+          grep -v " Invoked with" | grep "sr_fingerprint.*begin system_role:ad_integration" ||
+          { echo ERROR: BEGIN fingerprint not found; exit 1; };
+          journalctl --since "{{ __journal_start_time }}" --no-pager |
+          grep -v " Invoked with" | grep "sr_fingerprint.*success system_role:ad_integration" ||
+          { echo ERROR: SUCCESS fingerprint not found; exit 1; }
       changed_when: false
+      when: __register_dev_log.stat.exists
 
     - name: Check SSSD settings
       community.general.ini_file:


### PR DESCRIPTION
Test updates based on testing with bootc and on other platforms.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Tests:
- Update SSSD settings test to skip journal fingerprint checks when /dev/log is missing and ensure journalctl grep commands run under /bin/bash.