### PR TITLE
feat: new variable `ad_integration_secure_logging` defaulting to `true`

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,20 @@ All of the settings from `[domain/example.com]` will be moved to
 `[domain/EXAMPLE.COM]`, and the section `[domain/example.com]` will be removed
 from sssd.conf.
 
+#### ad_integration_secure_logging
+
+If `true`, suppress potentially sensitive output from tasks that handle
+credentials, secrets, and other sensitive data by setting `no_log: true` on
+those tasks. This prevents passwords, API tokens, private keys, and similar
+sensitive information from appearing in Ansible logs and console output.
+
+If you need to debug issues with credential handling or secret management, you
+can temporarily set `ad_integration_secure_logging: false` to see the full output from
+these tasks. However, be aware that this may expose sensitive information in
+logs, so it should only be used in development or troubleshooting scenarios.
+
+Default: true
+
 ## Example Playbook
 
 The following is an example playbook to setup direct Active Directory integration with AD domain `domain.example.com`, the join will be performed with user Administrator using the vault stored password. Prior to the join, the crypto policy for AD SUPPORT with RC4 encryption allowed will be set.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -155,3 +155,7 @@ ad_integration_manage_packages: true
 # to true, then the role will consolidate the data from those duplicate sections
 # and remove the duplicate sections
 ad_integration_sssd_merge_duplicate_sections: false
+
+# If true, suppress potentially sensitive output from tasks that
+# handle credentials, secrets, and other sensitive data.
+ad_integration_secure_logging: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -143,18 +143,18 @@
         path: "{{ __ad_integration_sssd_conf }}"
       register: __ad_sssd_conf_content
       when: __ad_sssd_conf_stat.stat.exists
-      no_log: true
+      no_log: "{{ ad_integration_secure_logging }}"
 
     - name: Set variables we will need for merging - 1
       set_fact:
         __ad_integration_matching_sections_before: "{{ __ad_sssd_conf | dict2items | selectattr('key', 'match', '(?i)' ~ __ad_sssd_section ~ '$') |
           list | items2dict }}"
-      no_log: true
+      no_log: "{{ ad_integration_secure_logging }}"
 
     - name: Set variables we will need for merging - 2
       set_fact:
         __ad_integration_has_duplicates: "{{ __ad_integration_matching_sections_before | length > 1 }}"
-      no_log: true
+      no_log: "{{ ad_integration_secure_logging }}"
 
 ## Handle rejoin, if applicable
 - name: Check if we are already joined to a domain
@@ -206,7 +206,7 @@
       {{ __ad_integration_realm_cmd | quote }} join -U {{ ad_integration_user | quote }} --membership-software
       {{ ad_integration_membership_software | quote }}
       {{ ad_integration_join_to_dc | quote }}
-  no_log: true
+  no_log: "{{ ad_integration_secure_logging }}"
   when: ad_integration_join_to_dc is not none
 
 - name: Build Join Command - Perform discovery-based realm join operation
@@ -220,7 +220,7 @@
       {{ __ad_integration_realm_cmd | quote }} join -U {{ ad_integration_user | quote }} --membership-software
       {{ ad_integration_membership_software | quote }}
       {{ ad_integration_realm | quote }}
-  no_log: true
+  no_log: "{{ ad_integration_secure_logging }}"
   when: ad_integration_join_to_dc is none
 
 - name: Show the join command for debug
@@ -241,7 +241,7 @@
   command: "{{ __ad_integration_join_command }}"
   args:
     stdin: "{{ ad_integration_password }}"
-  no_log: true
+  no_log: "{{ ad_integration_secure_logging }}"
   when:
     - ad_integration_join_to_dc != __ad_integration_sample_dc
     - ad_integration_realm != __ad_integration_sample_realm


### PR DESCRIPTION
Feature: Introduce the `ad_integration_secure_logging` variable that defaults to `true`.

Reason: Currently, all sensitive tasks use hard-coded no_log: true, which makes debugging difficult. Users cannot see credential-related output even when troubleshooting authentication or secret management issues.

Result:
  - Tasks handling credentials, secrets, and sensitive data now use no_log: "{{ ad_integration_secure_logging }}", allowing users to set ad_integration_secure_logging: false for debugging while maintaining secure defaults (true)
  - New variable ad_integration_secure_logging documented in README.md with guidance on when to disable it
  - Users can now debug credential and secret issues without modifying role code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a configurable secure logging flag for AD integration tasks to allow controlled visibility into sensitive operations.

New Features:
- Add the ad_integration_secure_logging variable to control whether sensitive AD integration tasks suppress their output.

Enhancements:
- Replace hard-coded no_log: true on credential- and secret-handling tasks with no_log controlled by ad_integration_secure_logging.
- Document the ad_integration_secure_logging option and its default in the role README.

Documentation:
- Document the new ad_integration_secure_logging variable, its default behavior, and guidance on when to disable it in README.md.