### PR TITLE
fix: set crypto_policies_reboot_ok to reboot and apply RC4 crypto policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ If true, the ad_integration role will set the crypto policy allowing RC4 encrypt
 
 Default: false
 
+**NOTE**: This may reboot the machine in order to apply the crypto policy, which is needed for the subsequent realm join.
+
 #### ad_integration_manage_dns
 
 If true, the ad_integration role will use fedora.linux_system_roles.network to add the provided dns server (see below) with manual DNS configuration to an existing connection. If true then the following variables are required:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,7 +27,7 @@
     ad_integration_manage_crypto_policies: true
   when: ad_integration_allow_rc4_crypto | bool
 
-- name: Ensure manage_crypt_policies is set with crypto_allow_rc4
+- name: Ensure ad_integration_manage_crypto_policies is set if ad_integration_allow_rc4_crypto is true
   fail:
     msg: >-
       ad_integration_manage_crypto_policies must be true if
@@ -107,6 +107,7 @@
     name: fedora.linux_system_roles.crypto_policies
   vars:
     crypto_policies_policy: "DEFAULT:AD-SUPPORT"
+    crypto_policies_reboot_ok: true
   when:
     - ad_integration_manage_crypto_policies | bool
     # Fedora and RHEL8+
@@ -121,6 +122,7 @@
     name: fedora.linux_system_roles.crypto_policies
   vars:
     crypto_policies_policy: "DEFAULT:AD-SUPPORT-LEGACY"
+    crypto_policies_reboot_ok: true
   when:
     - ad_integration_allow_rc4_crypto | bool
     - ansible_facts['distribution'] in __ad_integration_rh_distros

--- a/tests/tests_crypto_policies_reboot.yml
+++ b/tests/tests_crypto_policies_reboot.yml
@@ -1,0 +1,84 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Ensure ad_integration configures crypto policy and handles reboot
+  hosts: all,!ad
+  tags:
+    - tests::reboot
+  vars:
+    ad_integration_realm: sample-realm.com
+    ad_integration_allow_rc4_crypto: true
+  tasks:
+    - name: Include rh distro vars
+      include_vars: vars/rh_distros_vars.yml
+
+    - name: End host if crypto policies are not managed on this platform
+      meta: end_host
+      when: not (
+        ansible_facts['distribution'] == "Fedora" or
+        (ansible_facts['distribution'] in __ad_integration_rh_distros and
+         ansible_facts['distribution_version'] is version('8', '>='))
+        )
+
+    - name: Get current crypto policy
+      include_role:
+        name: fedora.linux_system_roles.crypto_policies
+      vars:
+        crypto_policies_policy: null
+
+    - name: Set vars for current crypto policy and expected crypto policy
+      set_fact:
+        __current_crypto_policy: "{{ crypto_policies_active | d('') }}"
+        __expected_crypto_policy: >-
+          {{ 'DEFAULT:AD-SUPPORT-LEGACY'
+             if ansible_facts['distribution'] in __ad_integration_rh_distros
+             and ansible_facts['distribution_version'] is version('9', '>=')
+             else 'DEFAULT:AD-SUPPORT' }}
+
+    - name: Read boot id before test
+      slurp:
+        src: /proc/sys/kernel/random/boot_id
+      register: __boot_id_before
+      changed_when: false
+
+    - name: Run test
+      when: __current_crypto_policy != __expected_crypto_policy
+      block:
+        - name: Run ad_integration role with ad_integration_allow_rc4_crypto set to true
+          include_tasks: tasks/run_role_with_clear_facts.yml
+          vars:
+            __sr_public: true
+
+        - name: Flush handlers
+          meta: flush_handlers
+
+        - name: Verify crypto policy was applied and reboot completed
+          assert:
+            that:
+              - crypto_policies_active == __expected_crypto_policy
+              - not crypto_policies_reboot_required
+
+        - name: Read boot id after reboot
+          slurp:
+            src: /proc/sys/kernel/random/boot_id
+          register: __boot_id_after_reboot
+          changed_when: false
+
+        - name: Check system was rebooted
+          assert:
+            that:
+              - __boot_id_after_reboot.content != __boot_id_before.content
+
+      always:
+        - name: Restore crypto policy to original policy
+          tags:
+            - tests::cleanup
+          include_role:
+            name: fedora.linux_system_roles.crypto_policies
+          vars:
+            crypto_policies_policy: "{{ __current_crypto_policy }}"
+            crypto_policies_reboot_ok: true
+
+        - name: Flush handlers after cleanup
+          tags:
+            - tests::cleanup
+          meta: flush_handlers


### PR DESCRIPTION
Cause: The machine was not rebooted after applying the crypto policy needed
when ad_integration_allow_rc4_crypto is true.

Consequence: The AD realm join fails because the incorrect crypto policy is used.

Fix: Set crypto_policies_reboot_ok to true when using the crypto_policies role to
ensure the machine is rebooted if necessary to apply the RC4 crypto policy.

Result: The realm join succeeds when using ad_integration_allow_rc4_crypto.

NOTE: This will now reboot the machine while running the ad_integration role
if ad_integration_allow_rc4_crypto is true, and the machine requires a reboot
in order to apply the policy.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Ensure AD integration applies the appropriate RC4 crypto policy by allowing the crypto_policies role to reboot the system when required.

Bug Fixes:
- Fix AD realm join failures when RC4 crypto is allowed by enabling reboots for crypto policy application.

Enhancements:
- Clarify task description related to managing crypto policies for RC4 support.
- Document that enabling RC4 crypto policies may reboot the machine during AD integration.
- Add fedora.linux_system_roles as a collection requirement for managing crypto policies.

Tests:
- Add an integration test verifying crypto policy configuration, required reboot behavior, and cleanup when RC4 crypto is enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added test coverage to validate crypto policy configuration and reboot behavior.

* **Bug Fixes**
  * Updated crypto policy handling to properly allow and manage system reboots when policies need to be applied.
  * Enhanced validation to ensure crypto policy management is properly configured.

* **Documentation**
  * Added warning note that enabling RC4-allowing crypto policy may trigger a machine reboot during realm join.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linux-system-roles/ad_integration/pull/194?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->